### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.7.2",
+      "version": "17.7.3",
       "commands": [
         "dotnet-coverage"
       ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "omnisharp.enableEditorConfigSupport": true,
-  "omnisharp.enableImportCompletion": true,
-  "omnisharp.enableRoslynAnalyzers": true
+  "omnisharp.enableRoslynAnalyzers": true,
+  "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true,
+  "dotnet.defaultSolution": "DotNetRepoTools.sln"
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Build" Version="17.5.0" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.5.5" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.6.11" />
     <PackageVersion Include="NuGet.Commands" Version="6.6.1" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
@@ -20,7 +20,7 @@
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" />
-    <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435" />
+    <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />

--- a/azure-pipelines/Get-SymbolFiles.ps1
+++ b/azure-pipelines/Get-SymbolFiles.ps1
@@ -43,8 +43,13 @@ $PDBs |% {
     }
 } |% {
     # Collect the DLLs/EXEs as well.
-    $dllPath = "$($_.Directory)/$($_.BaseName).dll"
-    $exePath = "$($_.Directory)/$($_.BaseName).exe"
+    $rootName = "$($_.Directory)/$($_.BaseName)"
+    if ($rootName.EndsWith('.ni')) {
+        $rootName = $rootName.Substring(0, $rootName.Length - 3)
+    }
+
+    $dllPath = "$rootName.dll"
+    $exePath = "$rootName.exe"
     if (Test-Path $dllPath) {
         $BinaryImagePath = $dllPath
     } elseif (Test-Path $exePath) {

--- a/src/Nerdbank.DotNetRepoTools/Git/TrimCommand.cs
+++ b/src/Nerdbank.DotNetRepoTools/Git/TrimCommand.cs
@@ -21,7 +21,7 @@ internal class TrimCommand : GitCommandBase
 	/// Gets the ref of the object that is the ultimate object of any branch.
 	/// Once a branch has merged into this ref, it can be deleted.
 	/// </summary>
-	required public string MergedInto { get; init; }
+	public required string MergedInto { get; init; }
 
 	/// <summary>
 	/// Gets a value indicating whether to delete local branches that have been merged into <see cref="MergedInto"/>.

--- a/src/Nerdbank.DotNetRepoTools/NuGet/ManagePackageVersionsCentrally.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/ManagePackageVersionsCentrally.cs
@@ -34,12 +34,12 @@ public class ManagePackageVersionsCentrally : MSBuildCommandBase
 	/// <summary>
 	/// Gets the path to the project file or repo to upgrade.
 	/// </summary>
-	required public string Path { get; init; }
+	public required string Path { get; init; }
 
 	/// <summary>
 	/// Gets the path to the Directory.Packages.props file.
 	/// </summary>
-	required public string DirectoryPackagesPropsPath { get; init; }
+	public required string DirectoryPackagesPropsPath { get; init; }
 
 	/// <summary>
 	/// Creates the command.

--- a/src/Nerdbank.DotNetRepoTools/NuGet/ReconcileVersionsCommand.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/ReconcileVersionsCommand.cs
@@ -31,12 +31,12 @@ public class ReconcileVersionsCommand : MSBuildCommandBase
 	/// <summary>
 	/// Gets the path to the project file to reconcile versions for.
 	/// </summary>
-	required public string ProjectPath { get; init; }
+	public required string ProjectPath { get; init; }
 
 	/// <summary>
 	/// Gets the target framework used to evaluate package dependencies.
 	/// </summary>
-	required public string TargetFramework { get; init; }
+	public required string TargetFramework { get; init; }
 
 	/// <summary>
 	/// Gets the set of version properties to disregard when updating package versions that were previously defined by properties.

--- a/src/Nerdbank.DotNetRepoTools/NuGet/TrimCommand.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/TrimCommand.cs
@@ -17,7 +17,7 @@ internal class TrimCommand : MSBuildCommandBase
 	{
 	}
 
-	required public string Project { get; init; }
+	public required string Project { get; init; }
 
 	/// <summary>
 	/// Creates the command.

--- a/src/Nerdbank.DotNetRepoTools/NuGet/UpgradeCommand.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/UpgradeCommand.cs
@@ -36,22 +36,22 @@ public class UpgradeCommand : MSBuildCommandBase
 	/// <summary>
 	/// Gets the ID of the package to be upgraded.
 	/// </summary>
-	required public string PackageId { get; init; }
+	public required string PackageId { get; init; }
 
 	/// <summary>
 	/// Gets the version to upgrade the package identified by <see cref="PackageId"/> to.
 	/// </summary>
-	required public string PackageVersion { get; init; }
+	public required string PackageVersion { get; init; }
 
 	/// <summary>
 	/// Gets the path to the project file or repo to upgrade.
 	/// </summary>
-	required public string Path { get; init; }
+	public required string Path { get; init; }
 
 	/// <summary>
 	/// Gets the target framework used to evaluate package dependencies.
 	/// </summary>
-	required public string TargetFramework { get; init; }
+	public required string TargetFramework { get; init; }
 
 	/// <summary>
 	/// Gets a value indicating whether all transitive dependencies will be explicitly added (not just updated as needed if they exist).


### PR DESCRIPTION
- Bump Microsoft.NET.Test.Sdk to 17.6.2
- Fix symbol file selection for R2R outputs
- Bump dotnet-coverage to 17.7.2
- Bump StyleCop.Analyzers.Unstable from 1.2.0.435 to 1.2.0.507 (#207)
- Bump dotnet-coverage from 17.7.2 to 17.7.3 (#208)
