### PR TITLE
Trim squashed branches too

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ***A CLI toolbox for repo maintenance***
 
 [![NuGet package](https://img.shields.io/nuget/v/Nerdbank.DotNetRepoTools.svg)](https://www.nuget.org/packages/Nerdbank.DotNetRepoTools)
-[![NuGet prerelease](https://img.shields.io/badge/nuget-prerelease-blue)](https://dev.azure.com/andrewarnott/OSS/_artifacts/feed/PublicCI/NuGet/Nerdbank.DotNetRepoTools)
+[![NuGet prerelease](https://img.shields.io/badge/nuget-CI-blue)](https://dev.azure.com/andrewarnott/OSS/_artifacts/feed/PublicCI/NuGet/Nerdbank.DotNetRepoTools)
 
 [![Build Status](https://dev.azure.com/andrewarnott/OSS/_apis/build/status/DotNetRepoTools/DotNetRepoTools?branchName=main)](https://dev.azure.com/andrewarnott/OSS/_build/latest?definitionId=74&branchName=main)
 
@@ -14,6 +14,10 @@
 Install or upgrade this tool with the following command:
 
     dotnet tool update -g Nerdbank.DotNetRepoTools
+
+Install or upgrade to the latest CI build with the following command:
+
+    dotnet tool update -g Nerdbank.DotNetRepoTools --prerelease --add-source https://pkgs.dev.azure.com/andrewarnott/OSS/_packaging/PublicCI/nuget/v3/index.json
 
 ## Commands
 

--- a/src/Nerdbank.DotNetRepoTools/CommandBase.cs
+++ b/src/Nerdbank.DotNetRepoTools/CommandBase.cs
@@ -14,6 +14,11 @@ namespace Nerdbank.DotNetRepoTools;
 public abstract class CommandBase : IDisposable
 {
 	/// <summary>
+	/// The <c>--what-if</c> option that can be used to preview the effects of a command without actually executing it.
+	/// </summary>
+	protected static readonly Option<bool> WhatIfOption = new("--what-if", "Prints what would be done without actually doing it.");
+
+	/// <summary>
 	/// Initializes a new instance of the <see cref="CommandBase"/> class
 	/// suitable for actually invoking the command.
 	/// </summary>

--- a/src/Nerdbank.DotNetRepoTools/Git/GitCommandBase.cs
+++ b/src/Nerdbank.DotNetRepoTools/Git/GitCommandBase.cs
@@ -71,7 +71,7 @@ internal abstract class GitCommandBase : CommandBase
 		{
 			RedirectStandardOutput = true,
 		};
-		Process process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to spawn git.");
+		using Process process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to spawn git.");
 		using (cancellationToken.Register(() => process.Kill()))
 		{
 			string? line;


### PR DESCRIPTION
This addition adds use of `git cherry` to detect branches that have nothing new to offer the target branch, possibly due to having been squashed instead of merged.