### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,21 +3,21 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.5.2",
+      "version": "7.5.3",
       "commands": [
         "pwsh"
       ],
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "17.14.2",
+      "version": "18.0.4",
       "commands": [
         "dotnet-coverage"
       ],
       "rollForward": false
     },
     "nbgv": {
-      "version": "3.7.115",
+      "version": "3.8.118",
       "commands": [
         "nbgv"
       ],

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:9.0.301-noble@sha256:f353951d75cd99696c912ba7a29a1c6905fe0c1c7613e12e5318efed40d9b287
+FROM mcr.microsoft.com/dotnet/sdk:9.0.305-noble@sha256:9ae2f68485dc3385e76e38524806fd159988b6e525ea5f27a4870bdf8bc0fe72
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,23 @@
+# Copilot instructions for this repository
+
+## High level guidance
+
+* Review the `CONTRIBUTING.md` file for instructions to build and test the software.
+* Set the `NBGV_GitEngine` environment variable to `Disabled` before running any `dotnet` or `msbuild` commands.
+
+## Software Design
+
+* Design APIs to be highly testable, and all functionality should be tested.
+* Avoid introducing binary breaking changes in public APIs of projects under `src` unless their project files have `IsPackable` set to `false`.
+
+## Testing
+
+* There should generally be one test project (under the `test` directory) per shipping project (under the `src` directory). Test projects are named after the project being tested with a `.Test` suffix.
+* Tests should use the Xunit testing framework.
+* Some tests are known to be unstable. When running tests, you should skip the unstable ones by running `dotnet test --filter "TestCategory!=FailsInCloudTest"`.
+
+## Coding style
+
+* Honor StyleCop rules and fix any reported build warnings *after* getting tests to pass.
+* In C# files, use namespace *statements* instead of namespace *blocks* for all new files.
+* Add API doc comments to all new public and internal members.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         - windows-2022
 
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: ⚙ Install prerequisites
@@ -87,8 +87,8 @@ jobs:
     name: 📃 Docs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
     - name: 🔗 Markup Link Checker (mlc)
-      uses: becheran/mlc@88c9db09b8dabab813a2edd13f955b36aa73657a # v0.22.0
+      uses: becheran/mlc@18a06b3aa2901ca197de59c8b0b1f54fdba6b3fa # v1.0.0
       with:
-        args: --do-not-warn-for-redirect-to https://learn.microsoft.com*,https://dotnet.microsoft.com/*,https://dev.azure.com/*,https://app.codecov.io/* -p docfx
+        args: --do-not-warn-for-redirect-to https://learn.microsoft.com*,https://dotnet.microsoft.com/*,https://dev.azure.com/*,https://app.codecov.io/* -p docfx -i https://www.npmjs.com/package/*,https://get.dot.net/

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
     # You can define any steps you want, and they will run before the agent starts.
     # If you do not check out your code, Copilot will do this for you.
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: ⚙ Install prerequisites

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,13 +5,6 @@ on:
     branches:
     - main
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  actions: read
-  pages: write
-  id-token: write
-  contents: read
-
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
@@ -20,12 +13,18 @@ concurrency:
 
 jobs:
   publish-docs:
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      actions: read
+      pages: write
+      id-token: write
+      contents: read
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: ⚙ Install prerequisites
@@ -35,7 +34,7 @@ jobs:
       name: 📚 Generate documentation
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
       with:
         path: docfx/_site
 

--- a/.github/workflows/libtemplate-update.yml
+++ b/.github/workflows/libtemplate-update.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,25 +11,17 @@ on:
 
 run-name: ${{ github.ref_name }}
 
-permissions:
-  actions: read
-  contents: write
-
 jobs:
   release:
     runs-on: ubuntu-24.04
+    permissions:
+      actions: read # Required to download artifacts
+      contents: write # Upload artifacts to Release
+      id-token: write # Required for NuGet CLI Login
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         fetch-depth: 1
-
-    - name: ⚙️ Initialization
-      shell: pwsh
-      run: |
-        if ('${{ secrets.NUGET_API_KEY }}') {
-          Write-Host "NUGET_API_KEY secret detected. NuGet packages will be pushed."
-          echo "NUGET_API_KEY_DEFINED=true" >> $env:GITHUB_ENV
-        }
 
     - name: 🔎 Search for build of ${{ github.ref }}
       shell: pwsh
@@ -69,7 +61,7 @@ jobs:
         Echo "runid=$runid" >> $env:GITHUB_OUTPUT
 
     - name: 🔻 Download deployables artifacts
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
       with:
         name: deployables-Linux
         path: ${{ runner.temp }}/deployables
@@ -87,8 +79,13 @@ jobs:
           gh release -R ${{ github.repository }} upload "${{ github.ref_name }}" $_.FullName
         }
 
+    - name: 🪪 Authorize NuGet package push
+      uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1
+      id: nuget-login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: 🚀 Push NuGet packages
       run: |
         rm global.json # allow whatever SDK is on the agent
-        dotnet nuget push ${{ runner.temp }}/deployables/*.nupkg --source https://api.nuget.org/v3/index.json -k '${{ secrets.NUGET_API_KEY }}'
-      if: ${{ env.NUGET_API_KEY_DEFINED == 'true' }}
+        dotnet nuget push ${{ runner.temp }}/deployables/*.nupkg --source https://api.nuget.org/v3/index.json -k '${{ steps.nuget-login.outputs.NUGET_API_KEY }}'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ This repository can be built on Windows, Linux, and OSX.
 
 Building, testing, and packing this repository can be done by using the standard dotnet CLI commands (e.g. `dotnet build`, `dotnet test`, `dotnet pack`, etc.).
 
-[pwsh]: https://docs.microsoft.com/powershell/scripting/install/installing-powershell?view=powershell-6
+[pwsh]: https://learn.microsoft.com/powershell/scripting/install/installing-powershell
 
 ## Releases
 
@@ -53,9 +53,9 @@ Push the tag.
 When your repo is hosted by GitHub and you are using GitHub Actions, you should create a GitHub Release using the standard GitHub UI.
 Having previously used `nbgv tag` and pushing the tag will help you identify the precise commit and name to use for this release.
 
-After publishing the release, the `.github\workflows\release.yml` workflow will be automatically triggered, which will:
+After publishing the release, the `.github/workflows/release.yml` workflow will be automatically triggered, which will:
 
-1. Find the most recent `.github\workflows\build.yml` GitHub workflow run of the tagged release.
+1. Find the most recent `.github/workflows/build.yml` GitHub workflow run of the tagged release.
 1. Upload the `deployables` artifact from that workflow run to your GitHub Release.
 1. If you have `NUGET_API_KEY` defined as a secret variable for your repo or org, any nuget packages in the `deployables` artifact will be pushed to nuget.org.
 
@@ -66,7 +66,7 @@ Trigger the pipeline by adding the `auto-release` tag on a run of your main `azu
 
 ## Tutorial and API documentation
 
-API and hand-written docs are found under the `docfx/` directory. and are built by [docfx](https://dotnet.github.io/docfx/).
+API and hand-written docs are found under the `docfx/` directory and are built by [docfx](https://dotnet.github.io/docfx/).
 
 You can make changes and host the site locally to preview them by switching to that directory and running the `dotnet docfx --serve` command.
 After making a change, you can rebuild the docs site while the localhost server is running by running `dotnet docfx` again from a separate terminal.
@@ -88,11 +88,11 @@ If Renovate is not creating pull requests when you expect it to, check that the 
 ### Maintaining your repo based on this template
 
 The best way to keep your repo in sync with Library.Template's evolving features and best practices is to periodically merge the template into your repo:
-`
+
 ```ps1
 git fetch
 git checkout origin/main
-.\tools\MergeFrom-Template.ps1
+./tools/MergeFrom-Template.ps1
 # resolve any conflicts, then commit the merge commit.
 git push origin -u HEAD
 ```

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
 
+    <!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/overview -->
+    <EnablePackageValidation>true</EnablePackageValidation>
+
     <!-- https://github.com/dotnet/msbuild/blob/main/documentation/ProjectReference-Protocol.md#setplatform-negotiation -->
     <EnableDynamicPlatformResolution>true</EnableDynamicPlatformResolution>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,9 +14,9 @@
     <PackageVersion Include="Xunit.Combinatorial" Version="2.0.24" />
   </ItemGroup>
   <ItemGroup Label="Library.Template">
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
-    <PackageVersion Include="xunit.v3" Version="2.0.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Put repo-specific GlobalPackageReference items in this group. -->
@@ -25,7 +25,7 @@
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <!-- The condition works around https://github.com/dotnet/sdk/issues/44951 -->
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.8.118" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
     <GlobalPackageReference Include="PolySharp" Version="1.15.0" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>

--- a/DotNetRepoTools.sln
+++ b/DotNetRepoTools.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.6.33427.3
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11023.372 main
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1CE9670B-D5FF-46A7-9D00-24E70E6ED48B}"
 	ProjectSection(SolutionItems) = preProject
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
+		.config\dotnet-tools.json = .config\dotnet-tools.json
 		global.json = global.json
 		nuget.config = nuget.config
 		README.md = README.md

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.301",
+    "version": "9.0.305",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/tools/Get-NuGetTool.ps1
+++ b/tools/Get-NuGetTool.ps1
@@ -6,7 +6,7 @@
 #>
 Param(
     [Parameter()]
-    [string]$NuGetVersion='6.12.2'
+    [string]$NuGetVersion='6.14.0'
 )
 
 $toolsPath = & "$PSScriptRoot\Get-TempToolsPath.ps1"

--- a/tools/Install-NuGetPackage.ps1
+++ b/tools/Install-NuGetPackage.ps1
@@ -1,0 +1,63 @@
+<#
+.SYNOPSIS
+    Installs a NuGet package.
+.PARAMETER PackageID
+    The Package ID to install.
+.PARAMETER Version
+    The version of the package to install. If unspecified, the latest stable release is installed.
+.PARAMETER Source
+    The package source feed to find the package to install from.
+.PARAMETER Prerelease
+    Include prerelease packages when searching for the latest version.
+.PARAMETER ExcludeVersion
+    Installs the package without adding the version to the folder name.
+.PARAMETER DirectDownload
+    Bypass the local cache when downloading packages.
+.PARAMETER PackagesDir
+    The directory to install the package to. By default, it uses the Packages folder at the root of the repo.
+.PARAMETER ConfigFile
+    The nuget.config file to use. By default, it uses :/nuget.config.
+.OUTPUTS
+    System.String. The path to the installed package.
+#>
+[CmdletBinding(SupportsShouldProcess=$true,ConfirmImpact='Low')]
+Param(
+    [Parameter(Position=1,Mandatory=$true)]
+    [string]$PackageId,
+    [Parameter()]
+    [string]$Version,
+    [Parameter()]
+    [string]$Source,
+    [Parameter()]
+    [switch]$Prerelease,
+    [Parameter()]
+    [switch]$ExcludeVersion,
+    [Parameter()]
+    [switch]$DirectDownload,
+    [Parameter()]
+    [string]$PackagesDir="$PSScriptRoot\..\packages",
+    [Parameter()]
+    [string]$ConfigFile="$PSScriptRoot\..\nuget.config",
+    [Parameter()]
+    [ValidateSet('Quiet','Normal','Detailed')]
+    [string]$Verbosity='normal'
+)
+
+$nugetPath = & "$PSScriptRoot\Get-NuGetTool.ps1"
+
+Write-Verbose "Installing $PackageId..."
+$nugetArgs = "Install",$PackageId,"-OutputDirectory",$PackagesDir,'-ConfigFile',$ConfigFile
+if ($Version) { $nugetArgs += "-Version",$Version }
+if ($Source) { $nugetArgs += "-FallbackSource",$Source }
+if ($Prerelease) { $nugetArgs += "-Prerelease" }
+if ($ExcludeVersion) { $nugetArgs += '-ExcludeVersion' }
+if ($DirectDownload) { $nugetArgs += '-DirectDownload' }
+$nugetArgs += '-Verbosity',$Verbosity
+
+if ($PSCmdlet.ShouldProcess($PackageId, 'nuget install')) {
+    $p = Start-Process $nugetPath $nugetArgs -NoNewWindow -Wait -PassThru
+    if ($null -ne $p.ExitCode -and $p.ExitCode -ne 0) { throw }
+}
+
+# Provide the path to the installed package directory to our caller.
+Write-Output (Get-ChildItem "$PackagesDir\$PackageId.*")[0].FullName


### PR DESCRIPTION
- Update becheran/mlc action to v1
- Update mcr.microsoft.com/dotnet/sdk:9.0.301-noble Docker digest to 2346351
- Update mcr.microsoft.com/dotnet/sdk:9.0.301-noble Docker digest to 4fd7d3e
- Update .NET SDK to v9.0.302
- Update dependency xunit.v3 to v3
- Update dependency xunit.runner.visualstudio to 3.1.2
- Update mcr.microsoft.com/dotnet/sdk:9.0.302-noble Docker digest to d442f82
- Update dependency xunit.runner.visualstudio to 3.1.3
- Update Dockerfile and global.json updates to v9.0.303
- Update mcr.microsoft.com/dotnet/sdk:9.0.303-noble Docker digest to a990afa
- Update mcr.microsoft.com/dotnet/sdk:9.0.303-noble Docker digest to 14fad15
- Update Dockerfile and global.json updates to v9.0.304
- Update actions/download-artifact action to v5
- Update mcr.microsoft.com/dotnet/sdk:9.0.304-noble Docker digest to 1f7ccf8
- Add copilot-instructions.md file
- Fix up contributing to work better on linux
- Add copilot instructions about avoiding unstable tests
- Update actions/checkout action to v5
- Update xunit
- Update mcr.microsoft.com/dotnet/sdk:9.0.304-noble Docker digest to 0b7186a
- Update actions/upload-pages-artifact action to v4
- Move GitHub workflow token permissions to per-job
- Update hyperlinks to learn.microsoft.com
- Remove stray backtick from CONTRIBUTING.md
- Add `Install-NuGetPackage.ps1` script
- Add switches to Install-NuGetPackage.ps1
- Update Dockerfile and global.json updates to v9.0.305
- Update mcr.microsoft.com/dotnet/sdk:9.0.305-noble Docker digest to 802e64a
- Drop extra `Pop-Location` from `Install-NuGetPackage.ps1`
- Update dependency powershell to v7.5.3
- Add API compat testing
- Switch API compat testing from dotnet tool to MSBuild
- Fix stray period in doc
- Bump nuget.exe to 6.14.0
- Update mcr.microsoft.com/dotnet/sdk:9.0.305-noble Docker digest to 604ef06
- Don't check npmjs.com doc links
- Add dotnet-tools.json to Solution Items
- Skip testing get.dot.net links
- Update nbgv and nerdbank.gitversioning updates to 3.8.118
- Switch to NuGet Trusted Publishing
- Update xunit
- Update dependency dotnet-coverage to v18
- Update mcr.microsoft.com/dotnet/sdk:9.0.305-noble Docker digest to 8a26226
- Update dependency Microsoft.NET.Test.Sdk to v18
- Update mcr.microsoft.com/dotnet/sdk:9.0.305-noble Docker digest to 9ae2f68
