### PR TITLE
Add nuget packing-projects command

### DIFF
--- a/src/Nerdbank.DotNetRepoTools/GraphCommand.cs
+++ b/src/Nerdbank.DotNetRepoTools/GraphCommand.cs
@@ -6,9 +6,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Microsoft.Build.Graph;
-using Microsoft.VisualStudio.SolutionPersistence;
-using Microsoft.VisualStudio.SolutionPersistence.Model;
-using Microsoft.VisualStudio.SolutionPersistence.Serializer;
 
 namespace Nerdbank.DotNetRepoTools;
 
@@ -63,13 +60,6 @@ public class GraphCommand : MSBuildCommandBase
 		/// Writes the graph as a Mermaid flowchart.
 		/// </summary>
 		Mermaid,
-	}
-
-	private enum InputKind
-	{
-		Project,
-		Sln,
-		Slnx,
 	}
 
 	/// <summary>
@@ -180,7 +170,7 @@ public class GraphCommand : MSBuildCommandBase
 		}
 
 		string extension = Path.GetExtension(fullInputPath);
-		if (!IsSupportedInput(extension))
+		if (!ProjectGraphInputLoader.IsSupportedInput(extension))
 		{
 			this.Error.WriteLine($"Unsupported input type '{extension}'. Expected a project file, .sln, or .slnx.");
 			this.ExitCode = 1;
@@ -198,7 +188,7 @@ public class GraphCommand : MSBuildCommandBase
 
 		try
 		{
-			GraphInput graphInput = await LoadGraphInputAsync(fullInputPath, excludedProjectPathPatterns, this.CancellationToken);
+			ProjectGraphInputLoader.GraphInput graphInput = await ProjectGraphInputLoader.LoadAsync(fullInputPath, projectPath => IsExcludedProjectPath(projectPath, excludedProjectPathPatterns), this.CancellationToken);
 			GraphModel graphModel = graphInput.EntryPoints.Count > 0
 				? BuildGraphModel(new ProjectGraph(graphInput.EntryPoints), graphInput.ExplicitSolutionProjects, excludedProjectPathPatterns, groupingPaths, highlightRules, fullInputPath, graphInput.InputKind, emittedPathBaseDirectory)
 				: new GraphModel([], [], []);
@@ -214,11 +204,6 @@ public class GraphCommand : MSBuildCommandBase
 		}
 	}
 
-	private static bool IsSupportedInput(string extension)
-		=> extension.Equals(".slnx", StringComparison.OrdinalIgnoreCase)
-		|| extension.Equals(".sln", StringComparison.OrdinalIgnoreCase)
-		|| extension.EndsWith("proj", StringComparison.OrdinalIgnoreCase);
-
 	private static string FormatException(Exception exception)
 	{
 		List<string> messages = [];
@@ -230,43 +215,7 @@ public class GraphCommand : MSBuildCommandBase
 		return string.Join(Environment.NewLine + "Caused by: ", messages);
 	}
 
-	private static async Task<GraphInput> LoadGraphInputAsync(string inputPath, IReadOnlyList<Regex> excludedProjectPathPatterns, CancellationToken cancellationToken)
-	{
-		string extension = Path.GetExtension(inputPath);
-		if (!extension.Equals(".sln", StringComparison.OrdinalIgnoreCase)
-			&& !extension.Equals(".slnx", StringComparison.OrdinalIgnoreCase))
-		{
-			return new GraphInput(
-			InputKind.Project,
-			IsExcludedProjectPath(inputPath, excludedProjectPathPatterns) ? [] : [new ProjectGraphEntryPoint(inputPath)],
-			new HashSet<string>(StringComparer.OrdinalIgnoreCase));
-		}
-
-		ISolutionSerializer serializer = SolutionSerializers.GetSerializerByMoniker(inputPath) ?? throw new InvalidOperationException($"No solution serializer is available for '{inputPath}'.");
-		SolutionModel solutionModel = await serializer.OpenAsync(inputPath, cancellationToken);
-		string solutionDirectory = Path.GetDirectoryName(inputPath)!;
-
-		HashSet<string> explicitProjects = new(StringComparer.OrdinalIgnoreCase);
-		List<ProjectGraphEntryPoint> entryPoints = [];
-		foreach (SolutionProjectModel solutionProject in solutionModel.SolutionProjects)
-		{
-			string projectPath = NormalizePathRelativeTo(solutionDirectory, solutionProject.FilePath);
-			if (IsExcludedProjectPath(projectPath, excludedProjectPathPatterns))
-			{
-				continue;
-			}
-
-			explicitProjects.Add(projectPath);
-			entryPoints.Add(new ProjectGraphEntryPoint(projectPath));
-		}
-
-		return new GraphInput(
-			extension.Equals(".slnx", StringComparison.OrdinalIgnoreCase) ? InputKind.Slnx : InputKind.Sln,
-			entryPoints,
-			explicitProjects);
-	}
-
-	private static GraphModel BuildGraphModel(ProjectGraph projectGraph, HashSet<string> explicitSolutionProjects, IReadOnlyList<Regex> excludedProjectPathPatterns, IReadOnlySet<string> groupingPaths, IReadOnlyList<ProjectHighlightRuleModel> highlightRules, string inputPath, InputKind inputKind, string emittedPathBaseDirectory)
+	private static GraphModel BuildGraphModel(ProjectGraph projectGraph, HashSet<string> explicitSolutionProjects, IReadOnlyList<Regex> excludedProjectPathPatterns, IReadOnlySet<string> groupingPaths, IReadOnlyList<ProjectHighlightRuleModel> highlightRules, string inputPath, ProjectGraphInputLoader.InputKind inputKind, string emittedPathBaseDirectory)
 	{
 		Dictionary<string, GraphNodeModel> projectNodesByPath = new(StringComparer.OrdinalIgnoreCase);
 		List<GraphNodeModel> containerNodes = [];
@@ -301,7 +250,7 @@ public class GraphCommand : MSBuildCommandBase
 		{
 			AddGroupingContainers(groupingPaths, projectNodesByPath.Values, groupingContainerNodesByPath, containerNodes, edges, edgeKeys, emittedPathBaseDirectory);
 		}
-		else if (inputKind == InputKind.Slnx && projectNodesByPath.Values.Any(node => node.IsExplicitSolutionProject))
+		else if (inputKind == ProjectGraphInputLoader.InputKind.Slnx && projectNodesByPath.Values.Any(node => node.IsExplicitSolutionProject))
 		{
 			AddSlnxExplicitProjectsContainer(inputPath, projectNodesByPath.Values.Where(node => node.IsExplicitSolutionProject), containerNodes, edges, edgeKeys);
 		}
@@ -984,22 +933,6 @@ public class GraphCommand : MSBuildCommandBase
 
 	private static string GetPathRelativeTo(string baseDirectory, string path)
 		=> Path.TrimEndingDirectorySeparator(Path.GetRelativePath(baseDirectory, path));
-
-	private sealed class GraphInput
-	{
-		public GraphInput(InputKind inputKind, IReadOnlyList<ProjectGraphEntryPoint> entryPoints, HashSet<string> explicitSolutionProjects)
-		{
-			this.InputKind = inputKind;
-			this.EntryPoints = entryPoints;
-			this.ExplicitSolutionProjects = explicitSolutionProjects;
-		}
-
-		public InputKind InputKind { get; }
-
-		public IReadOnlyList<ProjectGraphEntryPoint> EntryPoints { get; }
-
-		public HashSet<string> ExplicitSolutionProjects { get; }
-	}
 
 	private sealed class GraphModel
 	{

--- a/src/Nerdbank.DotNetRepoTools/GraphCommand.cs
+++ b/src/Nerdbank.DotNetRepoTools/GraphCommand.cs
@@ -188,7 +188,7 @@ public class GraphCommand : MSBuildCommandBase
 
 		try
 		{
-			ProjectGraphInputLoader.GraphInput graphInput = await ProjectGraphInputLoader.LoadAsync(fullInputPath, projectPath => IsExcludedProjectPath(projectPath, excludedProjectPathPatterns), this.CancellationToken);
+			ProjectGraphInput graphInput = await ProjectGraphInputLoader.LoadAsync(fullInputPath, projectPath => IsExcludedProjectPath(projectPath, excludedProjectPathPatterns), this.CancellationToken);
 			GraphModel graphModel = graphInput.EntryPoints.Count > 0
 				? BuildGraphModel(new ProjectGraph(graphInput.EntryPoints), graphInput.ExplicitSolutionProjects, excludedProjectPathPatterns, groupingPaths, highlightRules, fullInputPath, graphInput.InputKind, emittedPathBaseDirectory)
 				: new GraphModel([], [], []);
@@ -215,7 +215,7 @@ public class GraphCommand : MSBuildCommandBase
 		return string.Join(Environment.NewLine + "Caused by: ", messages);
 	}
 
-	private static GraphModel BuildGraphModel(ProjectGraph projectGraph, HashSet<string> explicitSolutionProjects, IReadOnlyList<Regex> excludedProjectPathPatterns, IReadOnlySet<string> groupingPaths, IReadOnlyList<ProjectHighlightRuleModel> highlightRules, string inputPath, ProjectGraphInputLoader.InputKind inputKind, string emittedPathBaseDirectory)
+	private static GraphModel BuildGraphModel(ProjectGraph projectGraph, HashSet<string> explicitSolutionProjects, IReadOnlyList<Regex> excludedProjectPathPatterns, IReadOnlySet<string> groupingPaths, IReadOnlyList<ProjectHighlightRuleModel> highlightRules, string inputPath, ProjectGraphInputKind inputKind, string emittedPathBaseDirectory)
 	{
 		Dictionary<string, GraphNodeModel> projectNodesByPath = new(StringComparer.OrdinalIgnoreCase);
 		List<GraphNodeModel> containerNodes = [];
@@ -250,7 +250,7 @@ public class GraphCommand : MSBuildCommandBase
 		{
 			AddGroupingContainers(groupingPaths, projectNodesByPath.Values, groupingContainerNodesByPath, containerNodes, edges, edgeKeys, emittedPathBaseDirectory);
 		}
-		else if (inputKind == ProjectGraphInputLoader.InputKind.Slnx && projectNodesByPath.Values.Any(node => node.IsExplicitSolutionProject))
+		else if (inputKind == ProjectGraphInputKind.Slnx && projectNodesByPath.Values.Any(node => node.IsExplicitSolutionProject))
 		{
 			AddSlnxExplicitProjectsContainer(inputPath, projectNodesByPath.Values.Where(node => node.IsExplicitSolutionProject), containerNodes, edges, edgeKeys);
 		}

--- a/src/Nerdbank.DotNetRepoTools/NuGet/NuGetCommand.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/NuGetCommand.cs
@@ -20,6 +20,7 @@ internal class NuGetCommand
 		DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance, nonInteractive: true);
 		Command nuget = new("nuget", "NuGet maintenance commands")
 		{
+			PackingProjectsCommand.CreateCommand(),
 			ReconcileVersionsCommand.CreateCommand(),
 			UpgradeCommand.CreateCommand(),
 			TrimCommand.CreateCommand(),

--- a/src/Nerdbank.DotNetRepoTools/NuGet/PackingProjectsCommand.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/PackingProjectsCommand.cs
@@ -87,7 +87,7 @@ public class PackingProjectsCommand : MSBuildCommandBase
 
 		try
 		{
-			ProjectGraphInputLoader.GraphInput graphInput = await ProjectGraphInputLoader.LoadAsync(fullInputPath, static _ => false, this.CancellationToken);
+			ProjectGraphInput graphInput = await ProjectGraphInputLoader.LoadAsync(fullInputPath, static _ => false, this.CancellationToken);
 			IReadOnlyList<PackingProjectInfo> packingProjects = graphInput.EntryPoints.Count > 0
 				? FindPackingProjects(new ProjectGraph(graphInput.EntryPoints), ResolveDisplayPathBaseDirectory(fullInputPath))
 				: [];
@@ -215,20 +215,4 @@ public class PackingProjectsCommand : MSBuildCommandBase
 	/// <param name="PackageId">The NuGet package ID.</param>
 	/// <param name="ProjectPath">The path to the project that produces the package.</param>
 	internal sealed record PackingProjectInfo(string PackageId, string ProjectPath);
-
-	/// <summary>
-	/// The supported output formats.
-	/// </summary>
-	public enum PackingProjectsOutputFormat
-	{
-		/// <summary>
-		/// Human-readable text output.
-		/// </summary>
-		Text,
-
-		/// <summary>
-		/// JSON output.
-		/// </summary>
-		Json,
-	}
 }

--- a/src/Nerdbank.DotNetRepoTools/NuGet/PackingProjectsCommand.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/PackingProjectsCommand.cs
@@ -1,0 +1,234 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Graph;
+
+namespace Nerdbank.DotNetRepoTools.NuGet;
+
+/// <summary>
+/// Lists the projects that produce NuGet packages.
+/// </summary>
+public class PackingProjectsCommand : MSBuildCommandBase
+{
+	private static readonly Argument<string> InputArgument = new("input")
+	{
+		Description = "The path to a project file, .sln, or .slnx file.",
+	};
+
+	private static readonly Option<PackingProjectsOutputFormat> FormatOption = new("--format", "-f")
+	{
+		Description = "The output format. Defaults to text.",
+	};
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="PackingProjectsCommand"/> class.
+	/// </summary>
+	public PackingProjectsCommand()
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="PackingProjectsCommand"/> class.
+	/// </summary>
+	/// <inheritdoc cref="CommandBase(ParseResult, CancellationToken)"/>
+	[SetsRequiredMembers]
+	public PackingProjectsCommand(ParseResult parseResult, CancellationToken cancellationToken)
+		: base(parseResult, cancellationToken)
+	{
+		this.InputPath = parseResult.GetValue(InputArgument)!;
+		this.Format = parseResult.GetValue(FormatOption);
+	}
+
+	/// <summary>
+	/// Gets the input project or solution path.
+	/// </summary>
+	public required string InputPath { get; init; }
+
+	/// <summary>
+	/// Gets the output format.
+	/// </summary>
+	public PackingProjectsOutputFormat Format { get; init; }
+
+	/// <summary>
+	/// Creates the command.
+	/// </summary>
+	/// <returns>The command.</returns>
+	internal static Command CreateCommand()
+	{
+		Command command = new("packing-projects", "Lists the projects that produce NuGet packages.")
+		{
+			InputArgument,
+			FormatOption,
+		};
+		command.SetAction((parseResult, cancellationToken) => new PackingProjectsCommand(parseResult, cancellationToken).ExecuteAndDisposeAsync());
+		return command;
+	}
+
+	/// <inheritdoc/>
+	protected override async Task ExecuteCoreAsync()
+	{
+		string fullInputPath = Path.GetFullPath(this.InputPath);
+		if (!File.Exists(fullInputPath))
+		{
+			this.Error.WriteLine($"Input file not found: {fullInputPath}");
+			this.ExitCode = 1;
+			return;
+		}
+
+		string extension = Path.GetExtension(fullInputPath);
+		if (!ProjectGraphInputLoader.IsSupportedInput(extension))
+		{
+			this.Error.WriteLine($"Unsupported input type '{extension}'. Expected a project file, .sln, or .slnx.");
+			this.ExitCode = 1;
+			return;
+		}
+
+		try
+		{
+			ProjectGraphInputLoader.GraphInput graphInput = await ProjectGraphInputLoader.LoadAsync(fullInputPath, static _ => false, this.CancellationToken);
+			IReadOnlyList<PackingProjectInfo> packingProjects = graphInput.EntryPoints.Count > 0
+				? FindPackingProjects(new ProjectGraph(graphInput.EntryPoints), ResolveDisplayPathBaseDirectory(fullInputPath))
+				: [];
+
+			this.WritePackingProjects(packingProjects);
+		}
+		catch (Exception ex)
+		{
+			this.Error.WriteLine(FormatException(ex));
+			this.ExitCode = 1;
+		}
+	}
+
+	private static IReadOnlyList<PackingProjectInfo> FindPackingProjects(ProjectGraph projectGraph, string displayPathBaseDirectory)
+	{
+		Dictionary<string, PackingProjectInfo> packingProjectsByPath = new(StringComparer.OrdinalIgnoreCase);
+		foreach (ProjectGraphNode graphNode in projectGraph.ProjectNodes)
+		{
+			ProjectInstance project = graphNode.ProjectInstance;
+			if (IsInnerBuild(project) || !ProducesPackage(project))
+			{
+				continue;
+			}
+
+			string fullProjectPath = NormalizePath(project.FullPath);
+			packingProjectsByPath.TryAdd(
+				fullProjectPath,
+				new PackingProjectInfo(
+					GetPackageId(project),
+					GetPathRelativeTo(displayPathBaseDirectory, fullProjectPath)));
+		}
+
+		return packingProjectsByPath.Values
+			.OrderBy(project => project.PackageId, StringComparer.OrdinalIgnoreCase)
+			.ThenBy(project => project.ProjectPath, StringComparer.OrdinalIgnoreCase)
+			.ToArray();
+	}
+
+	private static bool ProducesPackage(ProjectInstance project)
+	{
+		if (Path.GetExtension(project.FullPath).Equals(".nuproj", StringComparison.OrdinalIgnoreCase))
+		{
+			return true;
+		}
+
+		return IsTrue(project.GetPropertyValue("IsPackable"));
+	}
+
+	private static bool IsInnerBuild(ProjectInstance project)
+		=> IsTrue(project.GetPropertyValue("IsInnerBuild"))
+		|| (project.GetPropertyValue("TargetFramework").Length > 0 && project.GetPropertyValue("TargetFrameworks").Length > 0);
+
+	private static bool IsTrue(string propertyValue)
+		=> bool.TryParse(propertyValue, out bool result) && result;
+
+	private static string GetPackageId(ProjectInstance project)
+	{
+		bool isNuProj = Path.GetExtension(project.FullPath).Equals(".nuproj", StringComparison.OrdinalIgnoreCase);
+		string packageId = isNuProj
+			? project.GetPropertyValue("PackageName")
+			: project.GetPropertyValue("PackageId");
+		if (string.IsNullOrWhiteSpace(packageId) && isNuProj)
+		{
+			packageId = project.GetPropertyValue("PackageId");
+		}
+
+		if (string.IsNullOrWhiteSpace(packageId) && isNuProj)
+		{
+			packageId = project.GetPropertyValue("Id");
+		}
+
+		if (string.IsNullOrWhiteSpace(packageId))
+		{
+			packageId = project.GetPropertyValue("MSBuildProjectName");
+		}
+
+		return string.IsNullOrWhiteSpace(packageId) ? Path.GetFileNameWithoutExtension(project.FullPath) : packageId;
+	}
+
+	private static string FormatException(Exception exception)
+	{
+		List<string> messages = [];
+		for (Exception? current = exception; current is not null; current = current.InnerException)
+		{
+			messages.Add(current.Message.Trim());
+		}
+
+		return string.Join(Environment.NewLine + "Caused by: ", messages);
+	}
+
+	private static string ResolveDisplayPathBaseDirectory(string inputPath)
+	{
+		string inputDirectory = Path.GetDirectoryName(inputPath)!;
+		return FindGitRepoRoot(inputDirectory) ?? inputDirectory;
+	}
+
+	private static string NormalizePath(string path) => Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+
+	private static string GetPathRelativeTo(string baseDirectory, string path)
+		=> Path.TrimEndingDirectorySeparator(Path.GetRelativePath(baseDirectory, path));
+
+	private void WritePackingProjects(IReadOnlyList<PackingProjectInfo> packingProjects)
+	{
+		if (this.Format == PackingProjectsOutputFormat.Json)
+		{
+			this.Out.WriteLine(JsonSerializer.Serialize(packingProjects, SourceGenerationContext.Default.PackingProjectInfoArray));
+			return;
+		}
+
+		if (packingProjects.Count == 0)
+		{
+			this.Out.WriteLine("No packing projects found.");
+			return;
+		}
+
+		foreach (PackingProjectInfo packingProject in packingProjects)
+		{
+			this.Out.WriteLine($"{packingProject.PackageId}: {packingProject.ProjectPath}");
+		}
+	}
+
+	/// <summary>
+	/// Identifies a NuGet package and the project that produces it.
+	/// </summary>
+	/// <param name="PackageId">The NuGet package ID.</param>
+	/// <param name="ProjectPath">The path to the project that produces the package.</param>
+	internal sealed record PackingProjectInfo(string PackageId, string ProjectPath);
+
+	/// <summary>
+	/// The supported output formats.
+	/// </summary>
+	public enum PackingProjectsOutputFormat
+	{
+		/// <summary>
+		/// Human-readable text output.
+		/// </summary>
+		Text,
+
+		/// <summary>
+		/// JSON output.
+		/// </summary>
+		Json,
+	}
+}

--- a/src/Nerdbank.DotNetRepoTools/NuGet/PackingProjectsOutputFormat.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/PackingProjectsOutputFormat.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Nerdbank.DotNetRepoTools.NuGet;
+
+/// <summary>
+/// The supported output formats for packing project results.
+/// </summary>
+public enum PackingProjectsOutputFormat
+{
+	/// <summary>
+	/// Human-readable text output.
+	/// </summary>
+	Text,
+
+	/// <summary>
+	/// JSON output.
+	/// </summary>
+	Json,
+}

--- a/src/Nerdbank.DotNetRepoTools/ProjectGraphInput.cs
+++ b/src/Nerdbank.DotNetRepoTools/ProjectGraphInput.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Graph;
+
+namespace Nerdbank.DotNetRepoTools;
+
+/// <summary>
+/// The supported kinds of graph inputs.
+/// </summary>
+internal enum ProjectGraphInputKind
+{
+	/// <summary>
+	/// A single project file.
+	/// </summary>
+	Project,
+
+	/// <summary>
+	/// A traditional Visual Studio solution file.
+	/// </summary>
+	Sln,
+
+	/// <summary>
+	/// A solution XML file.
+	/// </summary>
+	Slnx,
+}
+
+/// <summary>
+/// The entry points and metadata used to build a project graph.
+/// </summary>
+/// <param name="InputKind">The kind of input file.</param>
+/// <param name="EntryPoints">The graph entry points.</param>
+/// <param name="ExplicitSolutionProjects">The projects explicitly listed in the solution, if any.</param>
+internal sealed record ProjectGraphInput(
+	ProjectGraphInputKind InputKind,
+	IReadOnlyList<ProjectGraphEntryPoint> EntryPoints,
+	HashSet<string> ExplicitSolutionProjects);

--- a/src/Nerdbank.DotNetRepoTools/ProjectGraphInputLoader.cs
+++ b/src/Nerdbank.DotNetRepoTools/ProjectGraphInputLoader.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Graph;
+using Microsoft.VisualStudio.SolutionPersistence;
+using Microsoft.VisualStudio.SolutionPersistence.Model;
+using Microsoft.VisualStudio.SolutionPersistence.Serializer;
+
+namespace Nerdbank.DotNetRepoTools;
+
+internal static class ProjectGraphInputLoader
+{
+	/// <summary>
+	/// Checks whether the file extension is supported as a graph input.
+	/// </summary>
+	/// <param name="extension">The file extension to inspect.</param>
+	/// <returns><see langword="true"/> if the extension is supported; otherwise <see langword="false"/>.</returns>
+	internal static bool IsSupportedInput(string extension)
+		=> extension.Equals(".slnx", StringComparison.OrdinalIgnoreCase)
+		|| extension.Equals(".sln", StringComparison.OrdinalIgnoreCase)
+		|| extension.EndsWith("proj", StringComparison.OrdinalIgnoreCase);
+
+	/// <summary>
+	/// Loads the graph entry points for a project or solution input.
+	/// </summary>
+	/// <param name="inputPath">The input project or solution path.</param>
+	/// <param name="isExcludedProjectPath">A predicate that identifies excluded projects.</param>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>The loaded graph input.</returns>
+	internal static async Task<GraphInput> LoadAsync(string inputPath, Func<string, bool> isExcludedProjectPath, CancellationToken cancellationToken)
+	{
+		string extension = Path.GetExtension(inputPath);
+		if (!extension.Equals(".sln", StringComparison.OrdinalIgnoreCase)
+			&& !extension.Equals(".slnx", StringComparison.OrdinalIgnoreCase))
+		{
+			return new GraphInput(
+				InputKind.Project,
+				isExcludedProjectPath(inputPath) ? [] : [new ProjectGraphEntryPoint(inputPath)],
+				new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+		}
+
+		ISolutionSerializer serializer = SolutionSerializers.GetSerializerByMoniker(inputPath) ?? throw new InvalidOperationException($"No solution serializer is available for '{inputPath}'.");
+		SolutionModel solutionModel = await serializer.OpenAsync(inputPath, cancellationToken);
+		string solutionDirectory = Path.GetDirectoryName(inputPath)!;
+
+		HashSet<string> explicitProjects = new(StringComparer.OrdinalIgnoreCase);
+		List<ProjectGraphEntryPoint> entryPoints = [];
+		foreach (SolutionProjectModel solutionProject in solutionModel.SolutionProjects)
+		{
+			string projectPath = NormalizePathRelativeTo(solutionDirectory, solutionProject.FilePath);
+			if (isExcludedProjectPath(projectPath))
+			{
+				continue;
+			}
+
+			explicitProjects.Add(projectPath);
+			entryPoints.Add(new ProjectGraphEntryPoint(projectPath));
+		}
+
+		return new GraphInput(
+			extension.Equals(".slnx", StringComparison.OrdinalIgnoreCase) ? InputKind.Slnx : InputKind.Sln,
+			entryPoints,
+			explicitProjects);
+	}
+
+	private static string NormalizePathRelativeTo(string baseDirectory, string path)
+		=> NormalizePath(Path.IsPathRooted(path) ? path : Path.Combine(baseDirectory, path));
+
+	private static string NormalizePath(string path) => Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+
+	/// <summary>
+	/// The supported kinds of graph inputs.
+	/// </summary>
+	internal enum InputKind
+	{
+		/// <summary>
+		/// A single project file.
+		/// </summary>
+		Project,
+
+		/// <summary>
+		/// A traditional Visual Studio solution file.
+		/// </summary>
+		Sln,
+
+		/// <summary>
+		/// A solution XML file.
+		/// </summary>
+		Slnx,
+	}
+
+	/// <summary>
+	/// The entry points and metadata used to build a project graph.
+	/// </summary>
+	/// <param name="InputKind">The kind of input file.</param>
+	/// <param name="EntryPoints">The graph entry points.</param>
+	/// <param name="ExplicitSolutionProjects">The projects explicitly listed in the solution, if any.</param>
+	internal sealed record GraphInput(
+		InputKind InputKind,
+		IReadOnlyList<ProjectGraphEntryPoint> EntryPoints,
+		HashSet<string> ExplicitSolutionProjects);
+}

--- a/src/Nerdbank.DotNetRepoTools/ProjectGraphInputLoader.cs
+++ b/src/Nerdbank.DotNetRepoTools/ProjectGraphInputLoader.cs
@@ -27,14 +27,14 @@ internal static class ProjectGraphInputLoader
 	/// <param name="isExcludedProjectPath">A predicate that identifies excluded projects.</param>
 	/// <param name="cancellationToken">A cancellation token.</param>
 	/// <returns>The loaded graph input.</returns>
-	internal static async Task<GraphInput> LoadAsync(string inputPath, Func<string, bool> isExcludedProjectPath, CancellationToken cancellationToken)
+	internal static async Task<ProjectGraphInput> LoadAsync(string inputPath, Func<string, bool> isExcludedProjectPath, CancellationToken cancellationToken)
 	{
 		string extension = Path.GetExtension(inputPath);
 		if (!extension.Equals(".sln", StringComparison.OrdinalIgnoreCase)
 			&& !extension.Equals(".slnx", StringComparison.OrdinalIgnoreCase))
 		{
-			return new GraphInput(
-				InputKind.Project,
+			return new ProjectGraphInput(
+				ProjectGraphInputKind.Project,
 				isExcludedProjectPath(inputPath) ? [] : [new ProjectGraphEntryPoint(inputPath)],
 				new HashSet<string>(StringComparer.OrdinalIgnoreCase));
 		}
@@ -57,8 +57,8 @@ internal static class ProjectGraphInputLoader
 			entryPoints.Add(new ProjectGraphEntryPoint(projectPath));
 		}
 
-		return new GraphInput(
-			extension.Equals(".slnx", StringComparison.OrdinalIgnoreCase) ? InputKind.Slnx : InputKind.Sln,
+		return new ProjectGraphInput(
+			extension.Equals(".slnx", StringComparison.OrdinalIgnoreCase) ? ProjectGraphInputKind.Slnx : ProjectGraphInputKind.Sln,
 			entryPoints,
 			explicitProjects);
 	}
@@ -67,36 +67,4 @@ internal static class ProjectGraphInputLoader
 		=> NormalizePath(Path.IsPathRooted(path) ? path : Path.Combine(baseDirectory, path));
 
 	private static string NormalizePath(string path) => Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
-
-	/// <summary>
-	/// The supported kinds of graph inputs.
-	/// </summary>
-	internal enum InputKind
-	{
-		/// <summary>
-		/// A single project file.
-		/// </summary>
-		Project,
-
-		/// <summary>
-		/// A traditional Visual Studio solution file.
-		/// </summary>
-		Sln,
-
-		/// <summary>
-		/// A solution XML file.
-		/// </summary>
-		Slnx,
-	}
-
-	/// <summary>
-	/// The entry points and metadata used to build a project graph.
-	/// </summary>
-	/// <param name="InputKind">The kind of input file.</param>
-	/// <param name="EntryPoints">The graph entry points.</param>
-	/// <param name="ExplicitSolutionProjects">The projects explicitly listed in the solution, if any.</param>
-	internal sealed record GraphInput(
-		InputKind InputKind,
-		IReadOnlyList<ProjectGraphEntryPoint> EntryPoints,
-		HashSet<string> ExplicitSolutionProjects);
 }

--- a/src/Nerdbank.DotNetRepoTools/SourceGenerationContext.cs
+++ b/src/Nerdbank.DotNetRepoTools/SourceGenerationContext.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Nerdbank.DotNetRepoTools.AzureDevOps;
+using Nerdbank.DotNetRepoTools.NuGet;
 
 namespace Nerdbank.DotNetRepoTools;
 
@@ -25,6 +26,8 @@ namespace Nerdbank.DotNetRepoTools;
 [JsonSerializable(typeof(GitRefUpdate))]
 [JsonSerializable(typeof(GitCommitRef))]
 [JsonSerializable(typeof(AzDOArray<GitCommitRef>))]
+[JsonSerializable(typeof(PackingProjectsCommand.PackingProjectInfo))]
+[JsonSerializable(typeof(PackingProjectsCommand.PackingProjectInfo[]))]
 [JsonSerializable(typeof(JsonNode))]
 [JsonSerializable(typeof(List<JsonPatch>))]
 internal partial class SourceGenerationContext : JsonSerializerContext

--- a/test/Nerdbank.DotNetRepoTools.Tests/NuGet/PackingProjectsCommandTests.cs
+++ b/test/Nerdbank.DotNetRepoTools.Tests/NuGet/PackingProjectsCommandTests.cs
@@ -1,0 +1,252 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine;
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.VisualStudio.SolutionPersistence;
+using Microsoft.VisualStudio.SolutionPersistence.Model;
+using Microsoft.VisualStudio.SolutionPersistence.Serializer;
+using Nerdbank.DotNetRepoTools.NuGet;
+
+namespace NuGet;
+
+[Collection(nameof(CurrentDirectorySensitiveTestCollection))]
+public class PackingProjectsCommandTests : CommandTestBase<PackingProjectsCommand>
+{
+	public PackingProjectsCommandTests(ITestOutputHelper logger)
+		: base(logger)
+	{
+	}
+
+	[Fact]
+	public void CreateCommand_DefinesFormatOptionAlias()
+	{
+		MethodInfo createCommandMethod = typeof(PackingProjectsCommand).GetMethod("CreateCommand", BindingFlags.Static | BindingFlags.NonPublic)!;
+		Command command = Assert.IsType<Command>(createCommandMethod.Invoke(obj: null, parameters: null));
+		Option formatOption = Assert.Single(command.Options, option => option.Name == "--format");
+		Assert.Contains("-f", formatOption.Aliases);
+	}
+
+	[Fact]
+	public async Task ListsPackingProjectsForProjectInput()
+	{
+		string repoRoot = Path.Combine(this.StagingDirectory, "repo");
+		(string rootProjectPath, _, _, _, _) = await this.CreatePackingProjectGraphAsync(repoRoot);
+		this.Command = new()
+		{
+			InputPath = rootProjectPath,
+		};
+
+		await this.ExecuteCommandAsync();
+
+		Assert.Equal(0, this.Command.ExitCode);
+		string[] lines = ((StringWriter)this.Command.Out).ToString()
+			.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+		Assert.Equal(
+			[
+				$"App: {Path.Combine("src", "App", "App.csproj")}",
+				$"Contoso.Legacy: {Path.Combine("packaging", "Legacy", "Legacy.nuproj")}",
+				$"Contoso.Multi: {Path.Combine("src", "Multi", "Multi.csproj")}",
+				$"Contoso.Packed: {Path.Combine("src", "Packed", "Packed.csproj")}",
+			],
+			lines);
+	}
+
+	[Fact]
+	public async Task WritesJsonForProjectInput()
+	{
+		string repoRoot = Path.Combine(this.StagingDirectory, "repo");
+		(string rootProjectPath, _, _, _, _) = await this.CreatePackingProjectGraphAsync(repoRoot);
+		this.Command = new()
+		{
+			InputPath = rootProjectPath,
+			Format = PackingProjectsCommand.PackingProjectsOutputFormat.Json,
+		};
+
+		await this.ExecuteCommandAsync();
+
+		Assert.Equal(0, this.Command.ExitCode);
+		using JsonDocument json = JsonDocument.Parse(((StringWriter)this.Command.Out).ToString());
+		Assert.Equal(4, json.RootElement.GetArrayLength());
+		Assert.Equal("App", json.RootElement[0].GetProperty("packageId").GetString());
+		Assert.Equal(Path.Combine("src", "App", "App.csproj"), json.RootElement[0].GetProperty("projectPath").GetString());
+		Assert.Equal("Contoso.Legacy", json.RootElement[1].GetProperty("packageId").GetString());
+		Assert.Equal(Path.Combine("packaging", "Legacy", "Legacy.nuproj"), json.RootElement[1].GetProperty("projectPath").GetString());
+		Assert.Equal("Contoso.Multi", json.RootElement[2].GetProperty("packageId").GetString());
+		Assert.Equal(Path.Combine("src", "Multi", "Multi.csproj"), json.RootElement[2].GetProperty("projectPath").GetString());
+		Assert.Equal("Contoso.Packed", json.RootElement[3].GetProperty("packageId").GetString());
+		Assert.Equal(Path.Combine("src", "Packed", "Packed.csproj"), json.RootElement[3].GetProperty("projectPath").GetString());
+	}
+
+	[Fact]
+	public async Task ListsPackingProjectsForSolutionInput()
+	{
+		string repoRoot = Path.Combine(this.StagingDirectory, "repo");
+		(string rootProjectPath, _, _, _, _) = await this.CreatePackingProjectGraphAsync(repoRoot);
+		string solutionPath = Path.Combine(repoRoot, "Repo.sln");
+		await File.WriteAllTextAsync(
+			solutionPath,
+			CreateSolutionFileContent(solutionPath, rootProjectPath),
+			TestContext.Current.CancellationToken);
+		this.Command = new()
+		{
+			InputPath = solutionPath,
+		};
+
+		await this.ExecuteCommandAsync();
+
+		Assert.Equal(0, this.Command.ExitCode);
+		string output = ((StringWriter)this.Command.Out).ToString();
+		Assert.Contains($"App: {Path.Combine("src", "App", "App.csproj")}", output);
+		Assert.Contains($"Contoso.Packed: {Path.Combine("src", "Packed", "Packed.csproj")}", output);
+		Assert.Contains($"Contoso.Multi: {Path.Combine("src", "Multi", "Multi.csproj")}", output);
+		Assert.Contains($"Contoso.Legacy: {Path.Combine("packaging", "Legacy", "Legacy.nuproj")}", output);
+	}
+
+	[Fact]
+	public async Task ListsPackingProjectsForSlnxInput()
+	{
+		string repoRoot = Path.Combine(this.StagingDirectory, "repo");
+		(string rootProjectPath, _, _, _, _) = await this.CreatePackingProjectGraphAsync(repoRoot);
+		string solutionPath = Path.Combine(repoRoot, "Repo.slnx");
+		await CreateSlnxFileAsync(solutionPath, rootProjectPath);
+		this.Command = new()
+		{
+			InputPath = solutionPath,
+		};
+
+		await this.ExecuteCommandAsync();
+
+		Assert.Equal(0, this.Command.ExitCode);
+		string output = ((StringWriter)this.Command.Out).ToString();
+		Assert.Contains($"App: {Path.Combine("src", "App", "App.csproj")}", output);
+		Assert.Contains($"Contoso.Packed: {Path.Combine("src", "Packed", "Packed.csproj")}", output);
+		Assert.Contains($"Contoso.Multi: {Path.Combine("src", "Multi", "Multi.csproj")}", output);
+		Assert.Contains($"Contoso.Legacy: {Path.Combine("packaging", "Legacy", "Legacy.nuproj")}", output);
+	}
+
+	private static string CreateSolutionFileContent(string solutionPath, string projectPath)
+	{
+		string solutionDirectory = Path.GetDirectoryName(solutionPath)!;
+		string projectPathFromSolution = Path.GetRelativePath(solutionDirectory, projectPath);
+		return $$"""
+			Microsoft Visual Studio Solution File, Format Version 12.00
+			# Visual Studio Version 17
+			VisualStudioVersion = 17.0.31903.59
+			MinimumVisualStudioVersion = 10.0.40219.1
+			Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App", "{{projectPathFromSolution}}", "{11111111-1111-1111-1111-111111111111}"
+			EndProject
+			Global
+			EndGlobal
+			""";
+	}
+
+	private static async Task CreateSlnxFileAsync(string solutionPath, params string[] projectPaths)
+	{
+		string solutionDirectory = Path.GetDirectoryName(solutionPath)!;
+		SolutionModel solutionModel = new();
+		solutionModel.AddBuildType("Debug");
+		solutionModel.AddPlatform("Any CPU");
+		foreach (string projectPath in projectPaths)
+		{
+			string projectPathFromSolution = Path.GetRelativePath(solutionDirectory, projectPath);
+			SolutionProjectModel project = solutionModel.AddProject(projectPathFromSolution, projectTypeName: null, folder: null);
+			project.DisplayName = Path.GetFileNameWithoutExtension(projectPath);
+		}
+
+		await ((ISolutionSerializer)SolutionSerializers.SlnXml).SaveAsync(solutionPath, solutionModel, TestContext.Current.CancellationToken);
+	}
+
+	private async Task<(string RootProjectPath, string PackedProjectPath, string MultiTargetProjectPath, string NuProjPath, string DisabledPackProjectPath)> CreatePackingProjectGraphAsync(string rootDirectory)
+	{
+		Directory.CreateDirectory(rootDirectory);
+		Directory.CreateDirectory(Path.Combine(rootDirectory, ".git"));
+
+		string rootProjectDirectory = Path.Combine(rootDirectory, "src", "App");
+		string packedProjectDirectory = Path.Combine(rootDirectory, "src", "Packed");
+		string multiTargetProjectDirectory = Path.Combine(rootDirectory, "src", "Multi");
+		string disabledPackProjectDirectory = Path.Combine(rootDirectory, "test", "DisabledPack");
+		string nuProjDirectory = Path.Combine(rootDirectory, "packaging", "Legacy");
+		Directory.CreateDirectory(rootProjectDirectory);
+		Directory.CreateDirectory(packedProjectDirectory);
+		Directory.CreateDirectory(multiTargetProjectDirectory);
+		Directory.CreateDirectory(disabledPackProjectDirectory);
+		Directory.CreateDirectory(nuProjDirectory);
+
+		string packedProjectPath = Path.Combine(packedProjectDirectory, "Packed.csproj");
+		await File.WriteAllTextAsync(
+			packedProjectPath,
+			"""
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+				<TargetFramework>net8.0</TargetFramework>
+				<IsPackable>true</IsPackable>
+				<PackageId>Contoso.Packed</PackageId>
+			  </PropertyGroup>
+			</Project>
+			""",
+			TestContext.Current.CancellationToken);
+
+		string multiTargetProjectPath = Path.Combine(multiTargetProjectDirectory, "Multi.csproj");
+		await File.WriteAllTextAsync(
+			multiTargetProjectPath,
+			"""
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+				<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+				<IsPackable>true</IsPackable>
+				<PackageId>Contoso.Multi</PackageId>
+			  </PropertyGroup>
+			</Project>
+			""",
+			TestContext.Current.CancellationToken);
+
+		string disabledPackProjectPath = Path.Combine(disabledPackProjectDirectory, "DisabledPack.csproj");
+		await File.WriteAllTextAsync(
+			disabledPackProjectPath,
+			"""
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+				<TargetFramework>net8.0</TargetFramework>
+				<IsPackable>false</IsPackable>
+				<PackageId>Contoso.Disabled</PackageId>
+			  </PropertyGroup>
+			</Project>
+			""",
+			TestContext.Current.CancellationToken);
+
+		string nuProjPath = Path.Combine(nuProjDirectory, "Legacy.nuproj");
+		await File.WriteAllTextAsync(
+			nuProjPath,
+			"""
+			<Project>
+			  <PropertyGroup>
+				<TargetFramework>net8.0</TargetFramework>
+				<PackageName>Contoso.Legacy</PackageName>
+			  </PropertyGroup>
+			</Project>
+			""",
+			TestContext.Current.CancellationToken);
+
+		string rootProjectPath = Path.Combine(rootProjectDirectory, "App.csproj");
+		await File.WriteAllTextAsync(
+			rootProjectPath,
+			$$"""
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+				<TargetFramework>net8.0</TargetFramework>
+			  </PropertyGroup>
+			  <ItemGroup>
+				<ProjectReference Include="{{Path.GetRelativePath(rootProjectDirectory, packedProjectPath)}}" />
+				<ProjectReference Include="{{Path.GetRelativePath(rootProjectDirectory, multiTargetProjectPath)}}" />
+				<ProjectReference Include="{{Path.GetRelativePath(rootProjectDirectory, disabledPackProjectPath)}}" />
+				<ProjectReference Include="{{Path.GetRelativePath(rootProjectDirectory, nuProjPath)}}" />
+			  </ItemGroup>
+			</Project>
+			""",
+			TestContext.Current.CancellationToken);
+
+		return (rootProjectPath, packedProjectPath, multiTargetProjectPath, nuProjPath, disabledPackProjectPath);
+	}
+}

--- a/test/Nerdbank.DotNetRepoTools.Tests/NuGet/PackingProjectsCommandTests.cs
+++ b/test/Nerdbank.DotNetRepoTools.Tests/NuGet/PackingProjectsCommandTests.cs
@@ -61,7 +61,7 @@ public class PackingProjectsCommandTests : CommandTestBase<PackingProjectsComman
 		this.Command = new()
 		{
 			InputPath = rootProjectPath,
-			Format = PackingProjectsCommand.PackingProjectsOutputFormat.Json,
+			Format = PackingProjectsOutputFormat.Json,
 		};
 
 		await this.ExecuteCommandAsync();
@@ -175,9 +175,7 @@ public class PackingProjectsCommandTests : CommandTestBase<PackingProjectsComman
 		Directory.CreateDirectory(nuProjDirectory);
 
 		string packedProjectPath = Path.Combine(packedProjectDirectory, "Packed.csproj");
-		await File.WriteAllTextAsync(
-			packedProjectPath,
-			"""
+		string packedProjectContent = """
 			<Project Sdk="Microsoft.NET.Sdk">
 			  <PropertyGroup>
 				<TargetFramework>net8.0</TargetFramework>
@@ -185,13 +183,14 @@ public class PackingProjectsCommandTests : CommandTestBase<PackingProjectsComman
 				<PackageId>Contoso.Packed</PackageId>
 			  </PropertyGroup>
 			</Project>
-			""",
+			""";
+		await File.WriteAllTextAsync(
+			packedProjectPath,
+			packedProjectContent,
 			TestContext.Current.CancellationToken);
 
 		string multiTargetProjectPath = Path.Combine(multiTargetProjectDirectory, "Multi.csproj");
-		await File.WriteAllTextAsync(
-			multiTargetProjectPath,
-			"""
+		string multiTargetProjectContent = """
 			<Project Sdk="Microsoft.NET.Sdk">
 			  <PropertyGroup>
 				<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
@@ -199,13 +198,14 @@ public class PackingProjectsCommandTests : CommandTestBase<PackingProjectsComman
 				<PackageId>Contoso.Multi</PackageId>
 			  </PropertyGroup>
 			</Project>
-			""",
+			""";
+		await File.WriteAllTextAsync(
+			multiTargetProjectPath,
+			multiTargetProjectContent,
 			TestContext.Current.CancellationToken);
 
 		string disabledPackProjectPath = Path.Combine(disabledPackProjectDirectory, "DisabledPack.csproj");
-		await File.WriteAllTextAsync(
-			disabledPackProjectPath,
-			"""
+		string disabledPackProjectContent = """
 			<Project Sdk="Microsoft.NET.Sdk">
 			  <PropertyGroup>
 				<TargetFramework>net8.0</TargetFramework>
@@ -213,26 +213,28 @@ public class PackingProjectsCommandTests : CommandTestBase<PackingProjectsComman
 				<PackageId>Contoso.Disabled</PackageId>
 			  </PropertyGroup>
 			</Project>
-			""",
+			""";
+		await File.WriteAllTextAsync(
+			disabledPackProjectPath,
+			disabledPackProjectContent,
 			TestContext.Current.CancellationToken);
 
 		string nuProjPath = Path.Combine(nuProjDirectory, "Legacy.nuproj");
-		await File.WriteAllTextAsync(
-			nuProjPath,
-			"""
+		string nuProjContent = """
 			<Project>
 			  <PropertyGroup>
 				<TargetFramework>net8.0</TargetFramework>
 				<PackageName>Contoso.Legacy</PackageName>
 			  </PropertyGroup>
 			</Project>
-			""",
+			""";
+		await File.WriteAllTextAsync(
+			nuProjPath,
+			nuProjContent,
 			TestContext.Current.CancellationToken);
 
 		string rootProjectPath = Path.Combine(rootProjectDirectory, "App.csproj");
-		await File.WriteAllTextAsync(
-			rootProjectPath,
-			$$"""
+		string rootProjectContent = $$"""
 			<Project Sdk="Microsoft.NET.Sdk">
 			  <PropertyGroup>
 				<TargetFramework>net8.0</TargetFramework>
@@ -244,7 +246,10 @@ public class PackingProjectsCommandTests : CommandTestBase<PackingProjectsComman
 				<ProjectReference Include="{{Path.GetRelativePath(rootProjectDirectory, nuProjPath)}}" />
 			  </ItemGroup>
 			</Project>
-			""",
+			""";
+		await File.WriteAllTextAsync(
+			rootProjectPath,
+			rootProjectContent,
 			TestContext.Current.CancellationToken);
 
 		return (rootProjectPath, packedProjectPath, multiTargetProjectPath, nuProjPath, disabledPackProjectPath);

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.4",
+  "version": "1.5",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
## Summary
This adds `nuget packing-projects` so repos can ask which packages a project, solution, or `.slnx` build produces and which projects produce them. The goal is to make package-producing projects discoverable without manually inspecting MSBuild metadata or running a separate pack analysis step.

The command builds an MSBuild `ProjectGraph`, reuses the same input handling as `graph`, and emits either human-readable text or JSON. It includes SDK-style projects when `IsPackable` is true, handles `.nuproj` projects separately, prefers `.nuproj` `PackageName` for package identity, and skips inner-build duplicates from multi-targeting projects.

## Testing
- `dotnet build -c Release`
- `dotnet test -c Release --no-build -- --filter-not-trait "FailsInCloudTest=true"`

## Notes
- The graph input loader was factored out of `GraphCommand` so the new command and `graph` stay aligned on project, `.sln`, and `.slnx` semantics.
- Added focused tests for project, solution, `.slnx`, JSON output, multi-target deduping, and `.nuproj` package-name handling.