### PR TITLE
Merge latest Library.Template updates

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "18.6.2",
+      "version": "18.7.0",
       "commands": [
         "dotnet-coverage"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.6.1",
+      "version": "7.6.2",
       "commands": [
         "pwsh"
       ],

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:10.0.300@sha256:dc8430e6024d454edadad1e160e1973be3cabbb7125998ef190d9e5c6adf7dbb
+FROM mcr.microsoft.com/dotnet/sdk:10.0.300@sha256:c0790639332692a0d56cdd81ed581cfd24d040d9839764c138994866df89a3b6
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.github/skills/bundle-dependency-prs/SKILL.md
+++ b/.github/skills/bundle-dependency-prs/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: bundle-dependency-prs
+description: Fix broken dependency update PRs and aggregate the ones that work into one PR.
+disable-model-invocation: true
+---
+
+# Instructions
+
+You have two goals:
+
+1. Get all dependency PRs to a state where their PR checks pass.
+2. Aggregate dependency PRs with passing checks into just one PR.
+
+You can identify dependency update PRs by those authored by `dependabot` or `renovate`.
+
+You'll find instructions for building and validating the repo in the [CONTRIBUTING.md](../../../CONTRIBUTING.md) doc.
+Always validate your changes locally before pushing them to the remote repository.
+
+When writing PR bodies or comments, avoid unmatched markdown code fences. Keep markdown well-formed.
+
+## Fix up dependency PRs with failing checks
+
+Before aggregating PRs, first try to fix any individual dependency update PRs with failing build/test checks.
+
+1. For the dependency PRs with failing build or test PR checks, check out their source branch and fix any issues.
+2. Push your fixes as fresh commits to the individual dependency PRs.
+3. If you can't fix a particular PR, add a comment to the PR describing your attempt and outcome.
+
+## Group dependency PRs that are ready to go
+
+Your next goal is to collect all the dependency updates that are ready to go into a single PR.
+
+1. Prepare a local branch called `bulkDepUpdates`.
+   1. Consider that a remote branch by the same name may already exist. If it does, base your local branch on it.
+   2. Merge `origin/main` into this branch.
+   3. Resolve any conflicts.
+2. For the dependency PRs whose build and test PR checks already pass, merge them into the `bulkDepUpdates` branch.
+   Consider that your local branch may have already merged an equivalent PR in the past (from a past run). If so, you should skip merging that PR.
+   Resolve any conflicts.
+   Build and run tests to validate your branch.
+3. Push the branch.
+4. Create a PR, if one does not already exist.

--- a/.github/skills/bundle-dependency-prs/SKILL.md
+++ b/.github/skills/bundle-dependency-prs/SKILL.md
@@ -18,6 +18,9 @@ Always validate your changes locally before pushing them to the remote repositor
 
 When writing PR bodies or comments, avoid unmatched markdown code fences. Keep markdown well-formed.
 
+For purposes of assessing PR readiness by its PR checks, consider docfx related checks to be irrelevant.
+If a docfx check fails but all other checks succeed, then that is a 'successful' dependency update PR.
+
 ## Fix up dependency PRs with failing checks
 
 Before aggregating PRs, first try to fix any individual dependency update PRs with failing build/test checks.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         - windows-2025
 
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: ⚙ Install prerequisites
@@ -75,7 +75,7 @@ jobs:
     name: 📃 Docs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: 🔗 Markup Link Checker (mlc)
       uses: becheran/mlc@7ec24825cefe0c9c8c6bac48430e1f69e3ec356e # v1.2.0
       with:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
     # You can define any steps you want, and they will run before the agent starts.
     # If you do not check out your code, Copilot will do this for you.
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: ⚙ Install prerequisites

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: ⚙ Install prerequisites

--- a/.github/workflows/libtemplate-update.yml
+++ b/.github/workflows/libtemplate-update.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,11 @@ This repository can be built on Windows, Linux, and OSX.
 
 Building, testing, and packing this repository can be done by using the standard dotnet CLI commands (e.g. `dotnet build`, `dotnet test`, `dotnet pack`, etc.).
 
-[pwsh]: https://learn.microsoft.com/powershell/scripting/install/installing-powershell
+## Testing
+
+You can use `dotnet test` to build and/or test the repo.
+
+There may be tests that are known to be unstable or have special requirements. These can be avoided by running tests using the [dotnet-test-cloud.ps1](tools/dotnet-test-cloud.ps1) script *after* running `dotnet build`.
 
 ## Releases
 
@@ -96,3 +100,5 @@ git checkout origin/main
 # resolve any conflicts, then commit the merge commit.
 git push origin -u HEAD
 ```
+
+[pwsh]: https://learn.microsoft.com/powershell/scripting/install/installing-powershell

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <!-- Put repo-specific PackageVersion items in this group. -->
   </ItemGroup>
   <ItemGroup Label="Library.Template">
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.7.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="$(MicrosoftTestingPlatformVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <!-- The condition works around https://github.com/dotnet/sdk/issues/44951 -->
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
-    <GlobalPackageReference Include="PolySharp" Version="1.15.0" />
+    <GlobalPackageReference Include="PolySharp" Version="1.16.0" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <MicrosoftTestingPlatformVersion>2.2.2</MicrosoftTestingPlatformVersion>
+    <MicrosoftTestingPlatformVersion>2.2.3</MicrosoftTestingPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Put repo-specific PackageVersion items in this group. -->

--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -59,7 +59,10 @@ $runtimeVersions = @()
 $windowsDesktopRuntimeVersions = @()
 $aspnetRuntimeVersions = @()
 if (!$SdkOnly) {
-    Get-ChildItem "$PSScriptRoot\..\src\*.*proj", "$PSScriptRoot\..\test\*.*proj", "$PSScriptRoot\..\Directory.Build.props" -Recurse | % {
+    $projFiles = Get-ChildItem "$PSScriptRoot\..\src\*.*proj", "$PSScriptRoot\..\test\*.*proj" -Recurse
+    $projFiles += Get-ChildItem "$PSScriptRoot\..\src\Directory.Build.props", "$PSScriptRoot\..\test\Directory.Build.props" -Recurse
+    $projFiles += Get-Item -LiteralPath "$PSScriptRoot\..\Directory.Build.props"
+    $projFiles | % {
         $projXml = [xml](Get-Content -LiteralPath $_)
         $pg = $projXml.Project.PropertyGroup
         if ($pg) {


### PR DESCRIPTION
This syncs DotNetRepoTools with the latest changes from `Library.Template` so the repo stays current with the shared build, tooling, and contributor workflow updates.

The merge pulls in the latest template updates across CI/workflow files, contributor guidance, devcontainer tooling, and package management. The only manual conflict was in `Directory.Packages.props`; that was resolved by taking the incoming Microsoft Testing Platform update to `2.2.3` while preserving this repo's existing `NuGetVersion`, `NuGetVersionForNet8`, and `NuGetVersionForNet9` overrides.

Notable updates included in this sync:

- refresh workflow and setup files under `.github/workflows`
- add the `bundle-dependency-prs` Copilot skill
- update contributor guidance around testing and template merging
- pull in the latest template dependency/tooling versions, including `PolySharp 1.16.0` and `Microsoft.Testing.Extensions.CodeCoverage 18.7.0`
- bring in the `Install-DotNetSdk.ps1` fix for recursive `Directory.Build.props` searches

Validation completed with `dotnet restore`, `dotnet build`, and `tools/dotnet-test-cloud.ps1`.