### PR TITLE
Default azdo pr create source and target branches

### DIFF
--- a/src/Nerdbank.DotNetRepoTools/AzureDevOps/AzDoRemoteInfo.cs
+++ b/src/Nerdbank.DotNetRepoTools/AzureDevOps/AzDoRemoteInfo.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using System.Text.RegularExpressions;
 
 namespace Nerdbank.DotNetRepoTools.AzureDevOps;
@@ -82,40 +81,8 @@ internal partial class AzDoRemoteInfo
 	/// <returns>An <see cref="AzDoRemoteInfo"/> instance if inference succeeded; otherwise, <see langword="null"/>.</returns>
 	public static AzDoRemoteInfo? TryInferFromGitRemote()
 	{
-		try
-		{
-			string? repoRoot = CommandBase.FindGitRepoRoot();
-			if (repoRoot is null)
-			{
-				return null;
-			}
-
-			ProcessStartInfo psi = new("git", "remote get-url origin")
-			{
-				RedirectStandardOutput = true,
-				RedirectStandardError = true,
-				WorkingDirectory = repoRoot,
-			};
-
-			using Process? process = Process.Start(psi);
-			if (process is null)
-			{
-				return null;
-			}
-
-			string url = process.StandardOutput.ReadToEnd().Trim();
-			process.WaitForExit(5000);
-			if (process.ExitCode != 0 || string.IsNullOrEmpty(url))
-			{
-				return null;
-			}
-
-			return TryParse(url);
-		}
-		catch
-		{
-			return null;
-		}
+		string? url = CommandBase.TryQueryGit("remote get-url origin");
+		return TryParse(url);
 	}
 
 	[GeneratedRegex(@"^https?://(?:[^@]+@)?dev\.azure\.com/(?<org>[^/]+)/(?<project>[^/]+)/_git/(?:_optimized/)?(?<repo>[^/]+?)(?:\.git)?/?$", RegexOptions.IgnoreCase)]

--- a/src/Nerdbank.DotNetRepoTools/AzureDevOps/AzureDevOpsCommandBase.cs
+++ b/src/Nerdbank.DotNetRepoTools/AzureDevOps/AzureDevOpsCommandBase.cs
@@ -14,13 +14,13 @@ namespace Nerdbank.DotNetRepoTools.AzureDevOps;
 /// </summary>
 public abstract class AzureDevOpsCommandBase : CommandBase
 {
-	private const string AzureDevOpsScope = "499b84ac-1321-427f-aa17-267ca6975798/.default";
-
 	/// <summary>
 	/// Inferred Azure DevOps remote information from the local git repository's <c>origin</c> remote URL.
 	/// Evaluated before option fields so we can determine whether options are required.
 	/// </summary>
 	private protected static readonly AzDoRemoteInfo? InferredRemoteInfo = AzDoRemoteInfo.TryInferFromGitRemote();
+
+	private const string AzureDevOpsScope = "499b84ac-1321-427f-aa17-267ca6975798/.default";
 
 	private static readonly OptionOrEnvVar AccessTokenOption = new("--access-token", "SYSTEM_ACCESSTOKEN", isRequired: false, description: "The access token to use to authenticate against the AzDO REST API. If not specified but the SYSTEM_ACCESSTOKEN environment variable is set, that value will be used. Otherwise the tool will attempt to acquire a token automatically from Visual Studio or Windows credentials.", doNotAppendToDescription: true);
 

--- a/src/Nerdbank.DotNetRepoTools/AzureDevOps/AzureDevOpsCommandBase.cs
+++ b/src/Nerdbank.DotNetRepoTools/AzureDevOps/AzureDevOpsCommandBase.cs
@@ -9,30 +9,41 @@ using Azure.Identity;
 
 namespace Nerdbank.DotNetRepoTools.AzureDevOps;
 
-internal abstract class AzureDevOpsCommandBase : CommandBase
+/// <summary>
+/// Base type for Azure DevOps commands.
+/// </summary>
+public abstract class AzureDevOpsCommandBase : CommandBase
 {
+	private const string AzureDevOpsScope = "499b84ac-1321-427f-aa17-267ca6975798/.default";
+
 	/// <summary>
 	/// Inferred Azure DevOps remote information from the local git repository's <c>origin</c> remote URL.
 	/// Evaluated before option fields so we can determine whether options are required.
 	/// </summary>
-	protected static readonly AzDoRemoteInfo? InferredRemoteInfo = AzDoRemoteInfo.TryInferFromGitRemote();
+	private protected static readonly AzDoRemoteInfo? InferredRemoteInfo = AzDoRemoteInfo.TryInferFromGitRemote();
 
-	protected static readonly OptionOrEnvVar AccessTokenOption = new("--access-token", "SYSTEM_ACCESSTOKEN", isRequired: false, description: "The access token to use to authenticate against the AzDO REST API. If not specified but the SYSTEM_ACCESSTOKEN environment variable is set, that value will be used. Otherwise the tool will attempt to acquire a token automatically from Visual Studio or Windows credentials.", doNotAppendToDescription: true);
+	private static readonly OptionOrEnvVar AccessTokenOption = new("--access-token", "SYSTEM_ACCESSTOKEN", isRequired: false, description: "The access token to use to authenticate against the AzDO REST API. If not specified but the SYSTEM_ACCESSTOKEN environment variable is set, that value will be used. Otherwise the tool will attempt to acquire a token automatically from Visual Studio or Windows credentials.", doNotAppendToDescription: true);
 
-	protected static readonly OptionOrEnvVar AccountOption = new("--account", "SYSTEM_COLLECTIONURI", isRequired: InferredRemoteInfo is null, "The AzDO account (organization) or URI (e.g. \"fabrikamfiber\" or \"https://dev.azure.com/fabrikamfiber/\". Can also be inferred from the git origin remote URL.");
+	private static readonly OptionOrEnvVar AccountOption = new("--account", "SYSTEM_COLLECTIONURI", isRequired: InferredRemoteInfo is null, "The AzDO account (organization) or URI (e.g. \"fabrikamfiber\" or \"https://dev.azure.com/fabrikamfiber/\". Can also be inferred from the git origin remote URL.");
 
-	protected static readonly OptionOrEnvVar ProjectOption = new("--project", "SYSTEM_TEAMPROJECT", isRequired: InferredRemoteInfo is null, "The AzDO project. Can also be inferred from the git origin remote URL.");
-
-	private const string AzureDevOpsScope = "499b84ac-1321-427f-aa17-267ca6975798/.default";
+	private static readonly OptionOrEnvVar ProjectOption = new("--project", "SYSTEM_TEAMPROJECT", isRequired: InferredRemoteInfo is null, "The AzDO project. Can also be inferred from the git origin remote URL.");
 
 	private HttpClient? httpClient;
 	private bool excludeManagedIdentityCredential;
 	private bool automaticCredentialAttemptFailedDueToManagedIdentity;
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="AzureDevOpsCommandBase"/> class.
+	/// </summary>
 	protected AzureDevOpsCommandBase()
 	{
 	}
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="AzureDevOpsCommandBase"/> class from parsed command-line data.
+	/// </summary>
+	/// <param name="parseResult">The parsed command-line result.</param>
+	/// <param name="cancellationToken">The cancellation token.</param>
 	[SetsRequiredMembers]
 	protected AzureDevOpsCommandBase(ParseResult parseResult, CancellationToken cancellationToken = default)
 		: base(parseResult, cancellationToken)
@@ -61,6 +72,9 @@ internal abstract class AzureDevOpsCommandBase : CommandBase
 		}
 	}
 
+	/// <summary>
+	/// Gets the Azure DevOps access token, if one was explicitly supplied.
+	/// </summary>
 	public string? AccessToken { get; init; }
 
 	/// <summary>
@@ -71,10 +85,19 @@ internal abstract class AzureDevOpsCommandBase : CommandBase
 	/// </value>
 	public required string CollectionUri { get; init; }
 
+	/// <summary>
+	/// Gets the Azure DevOps account name.
+	/// </summary>
 	public required string Account { get; init; }
 
+	/// <summary>
+	/// Gets the Azure DevOps project name.
+	/// </summary>
 	public required string Project { get; init; }
 
+	/// <summary>
+	/// Gets the HTTP client used for Azure DevOps requests.
+	/// </summary>
 	public HttpClient HttpClient => this.httpClient ??= this.CreateHttpClient();
 
 	/// <summary>
@@ -93,6 +116,10 @@ internal abstract class AzureDevOpsCommandBase : CommandBase
 		return git;
 	}
 
+	/// <summary>
+	/// Adds common Azure DevOps options to the specified command.
+	/// </summary>
+	/// <param name="command">The command to add options to.</param>
 	protected static new void AddCommonOptions(Command command)
 	{
 		CommandBase.AddCommonOptions(command);
@@ -105,6 +132,11 @@ internal abstract class AzureDevOpsCommandBase : CommandBase
 		command.Options.Add(ProjectOption);
 	}
 
+	/// <summary>
+	/// Converts the first character of a string to lowercase.
+	/// </summary>
+	/// <param name="value">The value to transform.</param>
+	/// <returns>The camel-cased value, or <see langword="null"/>.</returns>
 	[return: NotNullIfNotNull(nameof(value))]
 	protected static string? CamelCase(string? value)
 	{
@@ -116,8 +148,18 @@ internal abstract class AzureDevOpsCommandBase : CommandBase
 		return value.Length == 0 ? string.Empty : (char.ToLower(value[0]) + value[1..]);
 	}
 
+	/// <summary>
+	/// Adds a git ref prefix when the supplied ref name is not already fully qualified.
+	/// </summary>
+	/// <param name="defaultPrefix">The prefix to apply.</param>
+	/// <param name="refName">The ref name to normalize.</param>
+	/// <returns>The fully qualified ref name.</returns>
 	protected static string PrefixRef(string defaultPrefix, string refName) => refName.StartsWith("refs/") ? refName : defaultPrefix + refName;
 
+	/// <summary>
+	/// Creates the HTTP client used for Azure DevOps requests.
+	/// </summary>
+	/// <returns>The HTTP client.</returns>
 	protected virtual HttpClient CreateHttpClient()
 	{
 		HttpClient result = new()
@@ -182,6 +224,11 @@ internal abstract class AzureDevOpsCommandBase : CommandBase
 		return null;
 	}
 
+	/// <summary>
+	/// Writes an HTTP request in the same format used by <c>--what-if</c> and verbose output.
+	/// </summary>
+	/// <param name="request">The request to describe.</param>
+	/// <returns>A task that completes when the output has been written.</returns>
 	protected async Task WriteWhatIfAsync(HttpRequestMessage request)
 	{
 		this.Out.WriteLine($"{request.Method} {new Uri(this.HttpClient.BaseAddress!, request.RequestUri!).AbsoluteUri}");
@@ -267,6 +314,11 @@ internal abstract class AzureDevOpsCommandBase : CommandBase
 		return response;
 	}
 
+	/// <summary>
+	/// Prints a human-readable error message for a failed response.
+	/// </summary>
+	/// <param name="response">The response to inspect.</param>
+	/// <returns>A task that completes when the message has been written.</returns>
 	protected virtual async Task PrintErrorMessageAsync(HttpResponseMessage? response)
 	{
 		if (response is null)
@@ -298,8 +350,17 @@ internal abstract class AzureDevOpsCommandBase : CommandBase
 		}
 	}
 
+	/// <summary>
+	/// Determines whether a response represents a successful Azure DevOps call.
+	/// </summary>
+	/// <param name="response">The response to inspect.</param>
+	/// <returns><see langword="true"/> if the response is successful; otherwise, <see langword="false"/>.</returns>
 	protected virtual bool IsSuccessResponse([NotNullWhen(true)] HttpResponseMessage? response) => response is { IsSuccessStatusCode: true, StatusCode: not HttpStatusCode.NonAuthoritativeInformation };
 
+	/// <summary>
+	/// Gets the current user's Azure DevOps identity ID.
+	/// </summary>
+	/// <returns>The identity ID, or <see langword="null"/> if it could not be determined.</returns>
 	protected async Task<string?> WhoAmIAsync()
 	{
 		HttpRequestMessage request = new(HttpMethod.Get, "https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=7.1");
@@ -316,6 +377,11 @@ internal abstract class AzureDevOpsCommandBase : CommandBase
 		return null;
 	}
 
+	/// <summary>
+	/// Resolves an Azure DevOps identity by name.
+	/// </summary>
+	/// <param name="name">The identity name to search for.</param>
+	/// <returns>The resolved identity ID, or <see langword="null"/> if no single match was found.</returns>
 	protected async Task<string?> LookupIdentityAsync(string name)
 	{
 		HttpRequestMessage request = new(HttpMethod.Get, $"https://vssps.dev.azure.com/{this.Account}/_apis/identities?searchFilter=General&filterValue={Uri.EscapeDataString(name)}&queryMembership=None&api-version=6.0");

--- a/src/Nerdbank.DotNetRepoTools/AzureDevOps/GitRepository.cs
+++ b/src/Nerdbank.DotNetRepoTools/AzureDevOps/GitRepository.cs
@@ -17,5 +17,8 @@ internal class GitRepository
 
 	public required string WebUrl { get; set; }
 
+	/// <summary>
+	/// Gets or sets the repository's default branch as a fully-qualified ref, for example <c>refs/heads/main</c>.
+	/// </summary>
 	public string? DefaultBranch { get; set; }
 }

--- a/src/Nerdbank.DotNetRepoTools/AzureDevOps/GitRepository.cs
+++ b/src/Nerdbank.DotNetRepoTools/AzureDevOps/GitRepository.cs
@@ -16,4 +16,6 @@ internal class GitRepository
 	public required string Url { get; set; }
 
 	public required string WebUrl { get; set; }
+
+	public string? DefaultBranch { get; set; }
 }

--- a/src/Nerdbank.DotNetRepoTools/AzureDevOps/OutputFormat.cs
+++ b/src/Nerdbank.DotNetRepoTools/AzureDevOps/OutputFormat.cs
@@ -6,7 +6,7 @@ namespace Nerdbank.DotNetRepoTools.AzureDevOps;
 /// <summary>
 /// The output format for Azure DevOps commands that support text and JSON output.
 /// </summary>
-internal enum OutputFormat
+public enum OutputFormat
 {
 	/// <summary>
 	/// Human-readable text output (default).

--- a/src/Nerdbank.DotNetRepoTools/AzureDevOps/PullRequestCommandBase.cs
+++ b/src/Nerdbank.DotNetRepoTools/AzureDevOps/PullRequestCommandBase.cs
@@ -3,12 +3,23 @@
 
 namespace Nerdbank.DotNetRepoTools.AzureDevOps;
 
-internal abstract class PullRequestCommandBase : RepoCommandBase
+/// <summary>
+/// Base type for Azure DevOps pull request commands.
+/// </summary>
+public abstract class PullRequestCommandBase : RepoCommandBase
 {
+	/// <summary>
+	/// Initializes a new instance of the <see cref="PullRequestCommandBase"/> class.
+	/// </summary>
 	protected PullRequestCommandBase()
 	{
 	}
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="PullRequestCommandBase"/> class from parsed command-line data.
+	/// </summary>
+	/// <param name="parseResult">The parsed command-line result.</param>
+	/// <param name="cancellationToken">The cancellation token.</param>
 	[SetsRequiredMembers]
 	protected PullRequestCommandBase(ParseResult parseResult, CancellationToken cancellationToken = default)
 		: base(parseResult, cancellationToken)
@@ -33,6 +44,10 @@ internal abstract class PullRequestCommandBase : RepoCommandBase
 		return command;
 	}
 
+	/// <summary>
+	/// Creates the HTTP client used for pull request Azure DevOps requests.
+	/// </summary>
+	/// <returns>The HTTP client.</returns>
 	protected override HttpClient CreateHttpClient()
 	{
 		HttpClient client = base.CreateHttpClient();

--- a/src/Nerdbank.DotNetRepoTools/AzureDevOps/PullRequestCreateCommand.cs
+++ b/src/Nerdbank.DotNetRepoTools/AzureDevOps/PullRequestCreateCommand.cs
@@ -15,8 +15,8 @@ public class PullRequestCreateCommand : PullRequestCommandBase
 
 	private static readonly Option<string> TitleOption = new("--title") { Description = "The title of the pull request.", Required = true };
 	private static readonly Option<string> DescriptionOption = new("--description") { Description = "The description of the pull request. If an argument for this option is not specified on the command line, it will be pulled in from STDIN.", Arity = ArgumentArity.ZeroOrOne };
-	private static readonly Option<string> SourceRefNameOption = new("--source") { Description = "The name of the branch to merge from. This should not include the refs/heads/ prefix. Defaults to the current git branch when omitted." };
-	private static readonly Option<string> TargetRefNameOption = new("--target") { Description = "The name of the branch to merge into. This should not include the refs/heads/ prefix. Defaults to the repository's Azure DevOps default branch when omitted." };
+	private static readonly Option<string> SourceRefNameOption = new("--source") { Description = "The name of the branch to merge from. This may be a short branch name or a fully-qualified ref such as refs/heads/main. Defaults to the current git branch when omitted." };
+	private static readonly Option<string> TargetRefNameOption = new("--target") { Description = "The name of the branch to merge into. This may be a short branch name or a fully-qualified ref such as refs/heads/main. Defaults to the repository's Azure DevOps default branch when omitted." };
 	private static readonly Option<bool> IsDraftOption = new("--draft") { Description = "Whether the pull request is a draft." };
 	private static readonly Option<string[]> LabelsOption = new("--labels") { Description = "Labels to apply to the pull request.", AllowMultipleArgumentsPerToken = true };
 	private static readonly Option<OutputFormat> FormatOption = new("--format") { Description = "The output format to write." };
@@ -64,12 +64,14 @@ public class PullRequestCreateCommand : PullRequestCommandBase
 	public bool GetDescriptionFromStdIn { get; init; }
 
 	/// <summary>
-	/// Gets the source branch name, without the <c>refs/heads/</c> prefix.
+	/// Gets the source branch name.
+	/// This may be a short branch name or a fully-qualified ref such as <c>refs/heads/main</c>.
 	/// </summary>
 	public string? SourceRefName { get; init; }
 
 	/// <summary>
-	/// Gets the target branch name, without the <c>refs/heads/</c> prefix.
+	/// Gets the target branch name.
+	/// This may be a short branch name or a fully-qualified ref such as <c>refs/heads/main</c>.
 	/// </summary>
 	public string? TargetRefName { get; init; }
 

--- a/src/Nerdbank.DotNetRepoTools/AzureDevOps/PullRequestCreateCommand.cs
+++ b/src/Nerdbank.DotNetRepoTools/AzureDevOps/PullRequestCreateCommand.cs
@@ -6,29 +6,41 @@ using System.Text.Json.Nodes;
 
 namespace Nerdbank.DotNetRepoTools.AzureDevOps;
 
-internal class PullRequestCreateCommand : PullRequestCommandBase
+/// <summary>
+/// Creates a new Azure DevOps pull request.
+/// </summary>
+public class PullRequestCreateCommand : PullRequestCommandBase
 {
-	protected static readonly Option<string> TitleOption = new("--title") { Description = "The title of the pull request.", Required = true };
-	protected static readonly Option<string> DescriptionOption = new("--description") { Description = "The description of the pull request. If an argument for this option is not specified on the command line, it will be pulled in from STDIN.", Arity = ArgumentArity.ZeroOrOne };
-	protected static readonly Option<string> SourceRefNameOption = new("--source") { Description = "The name of the branch to merge from. This should not include the refs/heads/ prefix.", Required = true };
-	protected static readonly Option<string> TargetRefNameOption = new("--target") { Description = "The name of the branch to merge into. This should not include the refs/heads/ prefix.", Required = true };
-	protected static readonly Option<bool> IsDraftOption = new("--draft") { Description = "Whether the pull request is a draft." };
-	protected static readonly Option<string[]> LabelsOption = new("--labels") { Description = "Labels to apply to the pull request.", AllowMultipleArgumentsPerToken = true };
-	protected static readonly Option<OutputFormat> FormatOption = new("--format") { Description = "The output format to write." };
 	private const string JsonOutputFormat = "json";
 
+	private static readonly Option<string> TitleOption = new("--title") { Description = "The title of the pull request.", Required = true };
+	private static readonly Option<string> DescriptionOption = new("--description") { Description = "The description of the pull request. If an argument for this option is not specified on the command line, it will be pulled in from STDIN.", Arity = ArgumentArity.ZeroOrOne };
+	private static readonly Option<string> SourceRefNameOption = new("--source") { Description = "The name of the branch to merge from. This should not include the refs/heads/ prefix. Defaults to the current git branch when omitted." };
+	private static readonly Option<string> TargetRefNameOption = new("--target") { Description = "The name of the branch to merge into. This should not include the refs/heads/ prefix. Defaults to the repository's Azure DevOps default branch when omitted." };
+	private static readonly Option<bool> IsDraftOption = new("--draft") { Description = "Whether the pull request is a draft." };
+	private static readonly Option<string[]> LabelsOption = new("--labels") { Description = "Labels to apply to the pull request.", AllowMultipleArgumentsPerToken = true };
+	private static readonly Option<OutputFormat> FormatOption = new("--format") { Description = "The output format to write." };
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="PullRequestCreateCommand"/> class.
+	/// </summary>
 	public PullRequestCreateCommand()
 	{
 	}
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="PullRequestCreateCommand"/> class from parsed command-line data.
+	/// </summary>
+	/// <param name="parseResult">The parsed command-line result.</param>
+	/// <param name="cancellationToken">The cancellation token.</param>
 	[SetsRequiredMembers]
 	public PullRequestCreateCommand(ParseResult parseResult, CancellationToken cancellationToken)
 		: base(parseResult, cancellationToken)
 	{
 		this.Title = parseResult.GetValue(TitleOption)!;
 		this.Description = parseResult.GetValue(DescriptionOption);
-		this.SourceRefName = parseResult.GetValue(SourceRefNameOption)!;
-		this.TargetRefName = parseResult.GetValue(TargetRefNameOption)!;
+		this.SourceRefName = parseResult.GetValue(SourceRefNameOption);
+		this.TargetRefName = parseResult.GetValue(TargetRefNameOption);
 		this.IsDraft = parseResult.GetValue(IsDraftOption);
 		this.Labels = parseResult.GetValue(LabelsOption);
 		this.Format = parseResult.GetValue(FormatOption);
@@ -36,20 +48,44 @@ internal class PullRequestCreateCommand : PullRequestCommandBase
 		this.GetDescriptionFromStdIn = this.Description is null && parseResult.Tokens.Any(t => DescriptionOption.HasAlias(t.Value));
 	}
 
+	/// <summary>
+	/// Gets the pull request title.
+	/// </summary>
 	public required string Title { get; init; }
 
+	/// <summary>
+	/// Gets or sets the pull request description.
+	/// </summary>
 	public string? Description { get; set; }
 
+	/// <summary>
+	/// Gets a value indicating whether the description should be read from standard input.
+	/// </summary>
 	public bool GetDescriptionFromStdIn { get; init; }
 
-	public required string SourceRefName { get; init; }
+	/// <summary>
+	/// Gets the source branch name, without the <c>refs/heads/</c> prefix.
+	/// </summary>
+	public string? SourceRefName { get; init; }
 
-	public required string TargetRefName { get; init; }
+	/// <summary>
+	/// Gets the target branch name, without the <c>refs/heads/</c> prefix.
+	/// </summary>
+	public string? TargetRefName { get; init; }
 
+	/// <summary>
+	/// Gets a value indicating whether the pull request is a draft.
+	/// </summary>
 	public bool IsDraft { get; init; }
 
+	/// <summary>
+	/// Gets the labels to apply to the pull request.
+	/// </summary>
 	public string[]? Labels { get; init; }
 
+	/// <summary>
+	/// Gets the output format.
+	/// </summary>
 	public OutputFormat Format { get; init; }
 
 	internal static new Command CreateCommand()
@@ -70,8 +106,32 @@ internal class PullRequestCreateCommand : PullRequestCommandBase
 		return command;
 	}
 
+	/// <summary>
+	/// Executes the pull request creation.
+	/// </summary>
+	/// <returns>A task that completes when the operation finishes.</returns>
 	protected override async Task ExecuteCoreAsync()
 	{
+		string? sourceRefName = this.SourceRefName ?? CommandBase.TryGetCurrentGitBranch();
+		if (string.IsNullOrEmpty(sourceRefName))
+		{
+			this.Error.WriteLine("Specify --source or run this command from a git repository with a checked out branch.");
+			this.ExitCode = 1;
+			return;
+		}
+
+		string? targetRefName = await this.GetTargetRefNameAsync();
+		if (string.IsNullOrEmpty(targetRefName))
+		{
+			if (this.ExitCode == 0)
+			{
+				this.Error.WriteLine("Specify --target or configure a default branch for the Azure DevOps repository.");
+				this.ExitCode = 1;
+			}
+
+			return;
+		}
+
 		if (this.GetDescriptionFromStdIn)
 		{
 			this.Description = this.ReadFromStandardIn("Enter description for pull request.");
@@ -91,8 +151,8 @@ internal class PullRequestCreateCommand : PullRequestCommandBase
 			Content = JsonContent.Create(
 				new JsonObject
 				{
-					["sourceRefName"] = $"refs/heads/{this.SourceRefName}",
-					["targetRefName"] = $"refs/heads/{this.TargetRefName}",
+					["sourceRefName"] = PrefixRef("refs/heads/", sourceRefName),
+					["targetRefName"] = PrefixRef("refs/heads/", targetRefName),
 					["title"] = this.Title,
 					["description"] = this.Description ?? string.Empty,
 					["isDraft"] = this.IsDraft,
@@ -123,5 +183,16 @@ internal class PullRequestCreateCommand : PullRequestCommandBase
 				}
 			}
 		}
+	}
+
+	private async Task<string?> GetTargetRefNameAsync()
+	{
+		if (!string.IsNullOrEmpty(this.TargetRefName))
+		{
+			return this.TargetRefName;
+		}
+
+		GitRepository? repository = await this.GetRepositoryAsync();
+		return repository?.DefaultBranch;
 	}
 }

--- a/src/Nerdbank.DotNetRepoTools/AzureDevOps/RepoCommandBase.cs
+++ b/src/Nerdbank.DotNetRepoTools/AzureDevOps/RepoCommandBase.cs
@@ -5,14 +5,25 @@ using System.Net.Http.Json;
 
 namespace Nerdbank.DotNetRepoTools.AzureDevOps;
 
-internal abstract class RepoCommandBase : AzureDevOpsCommandBase
+/// <summary>
+/// Base type for Azure DevOps commands that operate on a repository.
+/// </summary>
+public abstract class RepoCommandBase : AzureDevOpsCommandBase
 {
-	protected static readonly OptionOrEnvVar RepoOption = new("--repo", "BUILD_REPOSITORY_NAME", isRequired: InferredRemoteInfo is null, "The name of the repo. Can also be inferred from the git origin remote URL.");
+	private static readonly OptionOrEnvVar RepoOption = new("--repo", "BUILD_REPOSITORY_NAME", isRequired: InferredRemoteInfo is null, "The name of the repo. Can also be inferred from the git origin remote URL.");
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="RepoCommandBase"/> class.
+	/// </summary>
 	protected RepoCommandBase()
 	{
 	}
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="RepoCommandBase"/> class from parsed command-line data.
+	/// </summary>
+	/// <param name="parseResult">The parsed command-line result.</param>
+	/// <param name="cancellationToken">The cancellation token.</param>
 	[SetsRequiredMembers]
 	protected RepoCommandBase(ParseResult parseResult, CancellationToken cancellationToken = default)
 		: base(parseResult, cancellationToken)
@@ -20,8 +31,15 @@ internal abstract class RepoCommandBase : AzureDevOpsCommandBase
 		this.Repo = parseResult.GetValue(RepoOption)!;
 	}
 
+	/// <summary>
+	/// Gets the repository name.
+	/// </summary>
 	public required string Repo { get; init; }
 
+	/// <summary>
+	/// Adds common repository options to the specified command.
+	/// </summary>
+	/// <param name="command">The command to add options to.</param>
 	protected static new void AddCommonOptions(Command command)
 	{
 		AzureDevOpsCommandBase.AddCommonOptions(command);
@@ -30,6 +48,10 @@ internal abstract class RepoCommandBase : AzureDevOpsCommandBase
 		command.Options.Add(RepoOption);
 	}
 
+	/// <summary>
+	/// Creates the HTTP client used for repository-scoped Azure DevOps requests.
+	/// </summary>
+	/// <returns>The HTTP client.</returns>
 	protected override HttpClient CreateHttpClient()
 	{
 		HttpClient client = base.CreateHttpClient();
@@ -41,10 +63,10 @@ internal abstract class RepoCommandBase : AzureDevOpsCommandBase
 	/// Gets the repository details by name.
 	/// </summary>
 	/// <returns>The repository details, or null if not found.</returns>
-	protected async Task<GitRepository?> GetRepositoryAsync()
+	private protected async Task<GitRepository?> GetRepositoryAsync()
 	{
-		// Use project-level client to query repository by name
-		HttpRequestMessage requestMessage = new(HttpMethod.Get, $"git/repositories/{this.Repo}?api-version=7.1");
+		Uri requestUri = new($"{this.CollectionUri}{Uri.EscapeDataString(this.Project)}/_apis/git/repositories/{Uri.EscapeDataString(this.Repo)}?api-version=7.1");
+		HttpRequestMessage requestMessage = new(HttpMethod.Get, requestUri);
 		HttpResponseMessage? response = await this.SendAsync(requestMessage, canReadContent: true);
 		if (this.IsSuccessResponse(response))
 		{

--- a/src/Nerdbank.DotNetRepoTools/CommandBase.cs
+++ b/src/Nerdbank.DotNetRepoTools/CommandBase.cs
@@ -177,13 +177,17 @@ public abstract class CommandBase : IDisposable
 				return null;
 			}
 
-			string output = process.StandardOutput.ReadToEnd().Trim();
+			Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+			Task<string> stderrTask = process.StandardError.ReadToEndAsync();
 			if (!process.WaitForExit(5000))
 			{
 				process.Kill(entireProcessTree: true);
+				process.WaitForExit();
 				return null;
 			}
 
+			Task.WaitAll(stdoutTask, stderrTask);
+			string output = stdoutTask.Result.Trim();
 			return process.ExitCode == 0 && output.Length > 0 ? output : null;
 		}
 		catch (InvalidOperationException)

--- a/src/Nerdbank.DotNetRepoTools/CommandBase.cs
+++ b/src/Nerdbank.DotNetRepoTools/CommandBase.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Text;
 using Microsoft;
 
@@ -145,6 +147,61 @@ public abstract class CommandBase : IDisposable
 
 		return null;
 	}
+
+	/// <summary>
+	/// Executes a git command from the current repository and returns its trimmed standard output.
+	/// </summary>
+	/// <param name="arguments">The git arguments to pass.</param>
+	/// <param name="startingPath">An optional path within the repository.</param>
+	/// <returns>The command output, or <see langword="null"/> if the repository or command could not be resolved.</returns>
+	internal static string? TryQueryGit(string arguments, string? startingPath = null)
+	{
+		string? repoRoot = FindGitRepoRoot(startingPath);
+		if (repoRoot is null)
+		{
+			return null;
+		}
+
+		ProcessStartInfo psi = new("git", arguments)
+		{
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			WorkingDirectory = repoRoot,
+		};
+
+		try
+		{
+			using Process? process = Process.Start(psi);
+			if (process is null)
+			{
+				return null;
+			}
+
+			string output = process.StandardOutput.ReadToEnd().Trim();
+			if (!process.WaitForExit(5000))
+			{
+				process.Kill(entireProcessTree: true);
+				return null;
+			}
+
+			return process.ExitCode == 0 && output.Length > 0 ? output : null;
+		}
+		catch (InvalidOperationException)
+		{
+			return null;
+		}
+		catch (Win32Exception)
+		{
+			return null;
+		}
+	}
+
+	/// <summary>
+	/// Attempts to identify the currently checked out git branch.
+	/// </summary>
+	/// <param name="startingPath">An optional path within the repository.</param>
+	/// <returns>The current branch name, or <see langword="null"/> if it could not be determined.</returns>
+	internal static string? TryGetCurrentGitBranch(string? startingPath = null) => TryQueryGit("branch --show-current", startingPath);
 
 	/// <summary>
 	/// Adds common options to the specified command.

--- a/test/Nerdbank.DotNetRepoTools.Tests/AzureDevOps/PullRequestCreateCommandTests.cs
+++ b/test/Nerdbank.DotNetRepoTools.Tests/AzureDevOps/PullRequestCreateCommandTests.cs
@@ -24,7 +24,11 @@ public class PullRequestCreateCommandTests : TestBase
 		Environment.CurrentDirectory = this.originalCurrentDirectory;
 		if (this.command is not null)
 		{
-			this.DumpConsole((StringWriter)this.command.Out, (StringWriter)this.command.Error);
+			if (this.command.Out is StringWriter outWriter && this.command.Error is StringWriter errorWriter)
+			{
+				this.DumpConsole(outWriter, errorWriter);
+			}
+
 			this.command.Dispose();
 		}
 
@@ -66,6 +70,8 @@ public class PullRequestCreateCommandTests : TestBase
 	{
 		Account = "fabrikam",
 		CollectionUri = "https://dev.azure.com/fabrikam/",
+		Error = new StringWriter(),
+		Out = new StringWriter(),
 		Project = "Project",
 		Repo = "Repo",
 		SourceRefName = sourceRefName,
@@ -76,8 +82,6 @@ public class PullRequestCreateCommandTests : TestBase
 	private async Task ExecuteCommandAsync()
 	{
 		Assert.NotNull(this.command);
-		this.command.Out = new StringWriter();
-		this.command.Error = new StringWriter();
 		this.MSBuild.SaveAll();
 		await this.command.ExecuteAndDisposeAsync();
 		this.MSBuild.ReloadEverything();

--- a/test/Nerdbank.DotNetRepoTools.Tests/AzureDevOps/PullRequestCreateCommandTests.cs
+++ b/test/Nerdbank.DotNetRepoTools.Tests/AzureDevOps/PullRequestCreateCommandTests.cs
@@ -94,8 +94,8 @@ public class PullRequestCreateCommandTests : TestBase
 	{
 		string repoPath = Path.Combine(this.StagingDirectory, Path.GetRandomFileName());
 		Directory.CreateDirectory(repoPath);
-		await RunGitAsync(repoPath, "init");
-		await RunGitAsync(repoPath, $"checkout -b {branchName}");
+		await this.RunGitAsync(repoPath, "init");
+		await this.RunGitAsync(repoPath, $"checkout -b {branchName}");
 		return repoPath;
 	}
 

--- a/test/Nerdbank.DotNetRepoTools.Tests/AzureDevOps/PullRequestCreateCommandTests.cs
+++ b/test/Nerdbank.DotNetRepoTools.Tests/AzureDevOps/PullRequestCreateCommandTests.cs
@@ -1,0 +1,174 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Nerdbank.DotNetRepoTools.AzureDevOps;
+
+[Collection(nameof(CurrentDirectorySensitiveTestCollection))]
+public class PullRequestCreateCommandTests : TestBase
+{
+	private readonly string originalCurrentDirectory = Environment.CurrentDirectory;
+	private TestablePullRequestCreateCommand? command;
+
+	public PullRequestCreateCommandTests(ITestOutputHelper logger)
+		: base(logger)
+	{
+	}
+
+	public override async ValueTask DisposeAsync()
+	{
+		Environment.CurrentDirectory = this.originalCurrentDirectory;
+		if (this.command is not null)
+		{
+			this.DumpConsole((StringWriter)this.command.Out, (StringWriter)this.command.Error);
+			this.command.Dispose();
+		}
+
+		await base.DisposeAsync();
+	}
+
+	[Fact]
+	public async Task DefaultsSourceAndTargetWhenOptionsAreOmitted()
+	{
+		string repoPath = await this.CreateGitRepoAsync("feature/test-pr");
+		Environment.CurrentDirectory = repoPath;
+		this.command = this.CreateCommand(sourceRefName: null, targetRefName: null);
+		this.command.RepositoryDefaultBranch = "refs/heads/main";
+
+		await this.ExecuteCommandAsync();
+
+		Assert.Equal(0, this.command.ExitCode);
+		JsonObject requestBody = this.GetPostedBody();
+		Assert.Equal("https://dev.azure.com/fabrikam/Project/_apis/git/repositories/Repo?api-version=7.1", this.command.RepositoryRequestUri);
+		Assert.Equal("refs/heads/feature/test-pr", requestBody["sourceRefName"]?.GetValue<string>());
+		Assert.Equal("refs/heads/main", requestBody["targetRefName"]?.GetValue<string>());
+	}
+
+	[Fact]
+	public async Task ReportsErrorWhenSourceCannotBeInferred()
+	{
+		Directory.CreateDirectory(this.StagingDirectory);
+		Environment.CurrentDirectory = this.StagingDirectory;
+		this.command = this.CreateCommand(sourceRefName: null, targetRefName: "main");
+
+		await this.ExecuteCommandAsync();
+
+		Assert.Equal(1, this.command.ExitCode);
+		Assert.Contains("Specify --source", ((StringWriter)this.command.Error).ToString(), StringComparison.Ordinal);
+		Assert.Null(this.command.PostBody);
+	}
+
+	private TestablePullRequestCreateCommand CreateCommand(string? sourceRefName, string? targetRefName) => new()
+	{
+		Account = "fabrikam",
+		CollectionUri = "https://dev.azure.com/fabrikam/",
+		Project = "Project",
+		Repo = "Repo",
+		SourceRefName = sourceRefName,
+		TargetRefName = targetRefName,
+		Title = "Test title",
+	};
+
+	private async Task ExecuteCommandAsync()
+	{
+		Assert.NotNull(this.command);
+		this.command.Out = new StringWriter();
+		this.command.Error = new StringWriter();
+		this.MSBuild.SaveAll();
+		await this.command.ExecuteAndDisposeAsync();
+		this.MSBuild.ReloadEverything();
+	}
+
+	private JsonObject GetPostedBody()
+	{
+		Assert.NotNull(this.command);
+		Assert.NotNull(this.command.PostBody);
+		return JsonNode.Parse(this.command.PostBody!)!.AsObject();
+	}
+
+	private async Task<string> CreateGitRepoAsync(string branchName)
+	{
+		string repoPath = Path.Combine(this.StagingDirectory, Path.GetRandomFileName());
+		Directory.CreateDirectory(repoPath);
+		await RunGitAsync(repoPath, "init");
+		await RunGitAsync(repoPath, $"checkout -b {branchName}");
+		return repoPath;
+	}
+
+	private async Task RunGitAsync(string workingDirectory, string arguments)
+	{
+		ProcessStartInfo startInfo = new("git", arguments)
+		{
+			RedirectStandardError = true,
+			RedirectStandardOutput = true,
+			WorkingDirectory = workingDirectory,
+		};
+
+		using Process process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to spawn git.");
+		string stdout = await process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+		string stderr = await process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+		await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+
+		Assert.True(process.ExitCode == 0, $"git {arguments} failed.{Environment.NewLine}{stdout}{stderr}");
+	}
+
+	internal sealed class TestablePullRequestCreateCommand : PullRequestCreateCommand
+	{
+		internal string? PostBody { get; private set; }
+
+		internal string? RepositoryDefaultBranch { get; set; }
+
+		internal string? RepositoryRequestUri { get; private set; }
+
+		protected override async Task<HttpResponseMessage?> SendAsync(HttpRequestMessage request, bool canReadContent)
+		{
+			if (request.Method == HttpMethod.Get)
+			{
+				this.RepositoryRequestUri = request.RequestUri?.AbsoluteUri;
+				return new(HttpStatusCode.OK)
+				{
+					Content = new StringContent(
+						$$"""
+						{
+						  "id": "{{Guid.NewGuid()}}",
+						  "url": "https://dev.azure.com/fabrikam/Project/_apis/git/repositories/Repo",
+						  "webUrl": "https://dev.azure.com/fabrikam/Project/_git/Repo",
+						  "defaultBranch": {{FormatJsonString(this.RepositoryDefaultBranch)}}
+						}
+						""",
+						Encoding.UTF8,
+						"application/json"),
+				};
+			}
+
+			if (request.Method == HttpMethod.Post)
+			{
+				this.PostBody = await request.Content!.ReadAsStringAsync(this.CancellationToken);
+				return new(HttpStatusCode.Created)
+				{
+					Content = new StringContent(
+						$$"""
+						{
+						  "pullRequestId": 123,
+						  "repository": {
+						    "id": "{{Guid.NewGuid()}}",
+						    "url": "https://dev.azure.com/fabrikam/Project/_apis/git/repositories/Repo",
+						    "webUrl": "https://dev.azure.com/fabrikam/Project/_git/Repo"
+						  }
+						}
+						""",
+						Encoding.UTF8,
+						"application/json"),
+				};
+			}
+
+			throw new InvalidOperationException($"Unexpected {request.Method} request.");
+		}
+
+		private static string FormatJsonString(string? value) => JsonSerializer.Serialize(value);
+	}
+}


### PR DESCRIPTION
This makes `azdo pr create` easier to use inside a repository by inferring the branch arguments that are usually obvious from context. When `--source` is omitted, the command now uses the current git branch, and when `--target` is omitted, it uses the Azure DevOps repository default branch.

The implementation also fixes the repository metadata lookup used for target inference. That lookup was previously built relative to a repo-scoped base URI, which produced a doubled `git/repositories/...` path and caused the 404 you saw when `--target` was omitted.

To keep the new behavior covered without `InternalsVisibleTo`, the PR-create command and the minimal supporting public surface needed by the test were exposed as public API with documentation. The regression test now subclasses the public command type, stubs the HTTP responses, and asserts both the inferred branch values and the repository lookup URI.