### PR TITLE
Merge latest from Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "nbgv": {
-      "version": "3.9.50",
+      "version": "3.10.85",
       "commands": [
         "nbgv"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.6.2",
+      "version": "7.6.3",
       "commands": [
         "pwsh"
       ],

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:10.0.301@sha256:548d93f8a18a1acbe6cc127bc4f47281430d34a9e35c18afa80a8d6741c2adc3
+FROM mcr.microsoft.com/dotnet/sdk:10.0.301@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630730f2c8201ed0572b295d5
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,9 @@ name: 🏭 Build
 on:
   push:
     branches:
-    - main
-    - 'v*.*'
-    - validate/*
+      - main
+      - "v*.*"
+      - validate/*
   pull_request:
   workflow_dispatch:
 
@@ -23,60 +23,60 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ubuntu-24.04
-        - macOS-15
-        - windows-2025
+          - ubuntu-24.04
+          - macOS-15
+          - windows-2025
 
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
-    - name: ⚙ Install prerequisites
-      run: |
-        ./init.ps1 -UpgradePrerequisites
-        dotnet --info
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+      - name: ⚙ Install prerequisites
+        run: |
+          ./init.ps1 -UpgradePrerequisites
+          dotnet --info
 
-        # Print mono version if it is present.
-        if (Get-Command mono -ErrorAction SilentlyContinue) {
-          mono --version
-        }
-      shell: pwsh
-    - name: ⚙️ Set pipeline variables based on source
-      run: tools/variables/_define.ps1
-      shell: pwsh
-    - name: 🛠 build
-      run: dotnet build -t:build,pack --no-restore -c ${{ env.BUILDCONFIGURATION }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904 /bl:"${{ runner.temp }}/_artifacts/build_logs/build.binlog"
-    - name: 🧪 test
-      run: tools/dotnet-test-cloud.ps1 -Configuration ${{ env.BUILDCONFIGURATION }} -Agent ${{ runner.os }}
-      shell: pwsh
-    - name: 💅🏻 Verify formatted code
-      run: dotnet format --verify-no-changes --no-restore
-      shell: pwsh
-      if: runner.os == 'Linux'
-    - name: 📚 Verify docfx build
-      run: dotnet docfx docfx/docfx.json --warningsAsErrors --disableGitFeatures
-      if: runner.os == 'Linux'
-    - name: ⚙ Update pipeline variables based on build outputs
-      run: tools/variables/_define.ps1
-      shell: pwsh
-    - name: 📢 Publish artifacts
-      uses: ./.github/actions/publish-artifacts
-      if: cancelled() == false
-    - name: 📢 Publish code coverage results to codecov.io
-      run: |
-        if ('${{ secrets.CODECOV_TOKEN }}') {
-          ./tools/publish-CodeCov.ps1 -CodeCovToken '${{ secrets.CODECOV_TOKEN }}' -PathToCodeCoverage "${{ runner.temp }}/_artifacts/coverageResults" -Name "${{ runner.os }} Coverage Results" -Flags "${{ runner.os }}"
-        }
-      shell: pwsh
-      timeout-minutes: 3
-      continue-on-error: true
+          # Print mono version if it is present.
+          if (Get-Command mono -ErrorAction SilentlyContinue) {
+            mono --version
+          }
+        shell: pwsh
+      - name: ⚙️ Set pipeline variables based on source
+        run: tools/variables/_define.ps1
+        shell: pwsh
+      - name: 🛠 build
+        run: dotnet build -t:build,pack --no-restore -c ${{ env.BUILDCONFIGURATION }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904 /bl:"${{ runner.temp }}/_artifacts/build_logs/build.binlog"
+      - name: 🧪 test
+        run: tools/dotnet-test-cloud.ps1 -Configuration ${{ env.BUILDCONFIGURATION }} -Agent ${{ runner.os }}
+        shell: pwsh
+      - name: 💅🏻 Verify formatted code
+        run: dotnet format --verify-no-changes --no-restore
+        shell: pwsh
+        if: runner.os == 'Linux'
+      - name: 📚 Verify docfx build
+        run: dotnet docfx docfx/docfx.json --warningsAsErrors --disableGitFeatures
+        if: runner.os == 'Linux'
+      - name: ⚙ Update pipeline variables based on build outputs
+        run: tools/variables/_define.ps1
+        shell: pwsh
+      - name: 📢 Publish artifacts
+        uses: ./.github/actions/publish-artifacts
+        if: cancelled() == false
+      - name: 📢 Publish code coverage results to codecov.io
+        run: |
+          if ('${{ secrets.CODECOV_TOKEN }}') {
+            ./tools/publish-CodeCov.ps1 -CodeCovToken '${{ secrets.CODECOV_TOKEN }}' -PathToCodeCoverage "${{ runner.temp }}/_artifacts/coverageResults" -Name "${{ runner.os }} Coverage Results" -Flags "${{ runner.os }}"
+          }
+        shell: pwsh
+        timeout-minutes: 3
+        continue-on-error: true
 
   docs:
     name: 📃 Docs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-    - name: 🔗 Markup Link Checker (mlc)
-      uses: becheran/mlc@7ec24825cefe0c9c8c6bac48430e1f69e3ec356e # v1.2.0
-      with:
-        args: --do-not-warn-for-redirect-to https://learn.microsoft.com*,https://dotnet.microsoft.com/*,https://dev.azure.com/*,https://app.codecov.io/* -p docfx -i https://www.npmjs.com/package/*,https://get.dot.net/
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: 🔗 Markup Link Checker (mlc)
+        uses: becheran/mlc@7ec24825cefe0c9c8c6bac48430e1f69e3ec356e # v1.2.0
+        with:
+          args: --do-not-warn-for-redirect-to https://learn.microsoft.com*,https://dotnet.microsoft.com/*,https://dev.azure.com/*,https://app.codecov.io/* -p docfx -i https://www.npmjs.com/package/*,https://get.dot.net/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,9 @@ name: 🏭 Build
 on:
   push:
     branches:
-      - main
-      - "v*.*"
-      - validate/*
+    - main
+    - 'v*.*'
+    - validate/*
   pull_request:
   workflow_dispatch:
 
@@ -23,60 +23,60 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-24.04
-          - macOS-15
-          - windows-2025
+        - ubuntu-24.04
+        - macOS-15
+        - windows-2025
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
-      - name: ⚙ Install prerequisites
-        run: |
-          ./init.ps1 -UpgradePrerequisites
-          dotnet --info
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+    - name: ⚙ Install prerequisites
+      run: |
+        ./init.ps1 -UpgradePrerequisites
+        dotnet --info
 
-          # Print mono version if it is present.
-          if (Get-Command mono -ErrorAction SilentlyContinue) {
-            mono --version
-          }
-        shell: pwsh
-      - name: ⚙️ Set pipeline variables based on source
-        run: tools/variables/_define.ps1
-        shell: pwsh
-      - name: 🛠 build
-        run: dotnet build -t:build,pack --no-restore -c ${{ env.BUILDCONFIGURATION }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904 /bl:"${{ runner.temp }}/_artifacts/build_logs/build.binlog"
-      - name: 🧪 test
-        run: tools/dotnet-test-cloud.ps1 -Configuration ${{ env.BUILDCONFIGURATION }} -Agent ${{ runner.os }}
-        shell: pwsh
-      - name: 💅🏻 Verify formatted code
-        run: dotnet format --verify-no-changes --no-restore
-        shell: pwsh
-        if: runner.os == 'Linux'
-      - name: 📚 Verify docfx build
-        run: dotnet docfx docfx/docfx.json --warningsAsErrors --disableGitFeatures
-        if: runner.os == 'Linux'
-      - name: ⚙ Update pipeline variables based on build outputs
-        run: tools/variables/_define.ps1
-        shell: pwsh
-      - name: 📢 Publish artifacts
-        uses: ./.github/actions/publish-artifacts
-        if: cancelled() == false
-      - name: 📢 Publish code coverage results to codecov.io
-        run: |
-          if ('${{ secrets.CODECOV_TOKEN }}') {
-            ./tools/publish-CodeCov.ps1 -CodeCovToken '${{ secrets.CODECOV_TOKEN }}' -PathToCodeCoverage "${{ runner.temp }}/_artifacts/coverageResults" -Name "${{ runner.os }} Coverage Results" -Flags "${{ runner.os }}"
-          }
-        shell: pwsh
-        timeout-minutes: 3
-        continue-on-error: true
+        # Print mono version if it is present.
+        if (Get-Command mono -ErrorAction SilentlyContinue) {
+          mono --version
+        }
+      shell: pwsh
+    - name: ⚙️ Set pipeline variables based on source
+      run: tools/variables/_define.ps1
+      shell: pwsh
+    - name: 🛠 build
+      run: dotnet build -t:build,pack --no-restore -c ${{ env.BUILDCONFIGURATION }} -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904 /bl:"${{ runner.temp }}/_artifacts/build_logs/build.binlog"
+    - name: 🧪 test
+      run: tools/dotnet-test-cloud.ps1 -Configuration ${{ env.BUILDCONFIGURATION }} -Agent ${{ runner.os }}
+      shell: pwsh
+    - name: 💅🏻 Verify formatted code
+      run: dotnet format --verify-no-changes --no-restore
+      shell: pwsh
+      if: runner.os == 'Linux'
+    - name: 📚 Verify docfx build
+      run: dotnet docfx docfx/docfx.json --warningsAsErrors --disableGitFeatures
+      if: runner.os == 'Linux'
+    - name: ⚙ Update pipeline variables based on build outputs
+      run: tools/variables/_define.ps1
+      shell: pwsh
+    - name: 📢 Publish artifacts
+      uses: ./.github/actions/publish-artifacts
+      if: cancelled() == false
+    - name: 📢 Publish code coverage results to codecov.io
+      run: |
+        if ('${{ secrets.CODECOV_TOKEN }}') {
+          ./tools/publish-CodeCov.ps1 -CodeCovToken '${{ secrets.CODECOV_TOKEN }}' -PathToCodeCoverage "${{ runner.temp }}/_artifacts/coverageResults" -Name "${{ runner.os }} Coverage Results" -Flags "${{ runner.os }}"
+        }
+      shell: pwsh
+      timeout-minutes: 3
+      continue-on-error: true
 
   docs:
     name: 📃 Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: 🔗 Markup Link Checker (mlc)
-        uses: becheran/mlc@7ec24825cefe0c9c8c6bac48430e1f69e3ec356e # v1.2.0
-        with:
-          args: --do-not-warn-for-redirect-to https://learn.microsoft.com*,https://dotnet.microsoft.com/*,https://dev.azure.com/*,https://app.codecov.io/* -p docfx -i https://www.npmjs.com/package/*,https://get.dot.net/
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: 🔗 Markup Link Checker (mlc)
+      uses: becheran/mlc@7ec24825cefe0c9c8c6bac48430e1f69e3ec356e # v1.2.0
+      with:
+        args: --do-not-warn-for-redirect-to https://learn.microsoft.com*,https://dotnet.microsoft.com/*,https://dev.azure.com/*,https://app.codecov.io/* -p docfx -i https://www.npmjs.com/package/*,https://get.dot.net/

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -6,12 +6,12 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+    - main
     paths:
-      - .github/workflows/copilot-setup-steps.yml
+    - .github/workflows/copilot-setup-steps.yml
   pull_request:
     paths:
-      - .github/workflows/copilot-setup-steps.yml
+    - .github/workflows/copilot-setup-steps.yml
 
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
@@ -26,16 +26,16 @@ jobs:
     # You can define any steps you want, and they will run before the agent starts.
     # If you do not check out your code, Copilot will do this for you.
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
-      - name: ⚙ Install prerequisites
-        run: |
-          ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
-          dotnet --info
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+    - name: ⚙ Install prerequisites
+      run: |
+        ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
+        dotnet --info
 
-          # Print mono version if it is present.
-          if (Get-Command mono -ErrorAction SilentlyContinue) {
-            mono --version
-          }
-        shell: pwsh
+        # Print mono version if it is present.
+        if (Get-Command mono -ErrorAction SilentlyContinue) {
+          mono --version
+        }
+      shell: pwsh

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -6,12 +6,12 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
+      - main
     paths:
-    - .github/workflows/copilot-setup-steps.yml
+      - .github/workflows/copilot-setup-steps.yml
   pull_request:
     paths:
-    - .github/workflows/copilot-setup-steps.yml
+      - .github/workflows/copilot-setup-steps.yml
 
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
@@ -26,16 +26,16 @@ jobs:
     # You can define any steps you want, and they will run before the agent starts.
     # If you do not check out your code, Copilot will do this for you.
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
-    - name: ⚙ Install prerequisites
-      run: |
-        ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
-        dotnet --info
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+      - name: ⚙ Install prerequisites
+        run: |
+          ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
+          dotnet --info
 
-        # Print mono version if it is present.
-        if (Get-Command mono -ErrorAction SilentlyContinue) {
-          mono --version
-        }
-      shell: pwsh
+          # Print mono version if it is present.
+          if (Get-Command mono -ErrorAction SilentlyContinue) {
+            mono --version
+          }
+        shell: pwsh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: 📚 Docs
 on:
   push:
     branches:
-      - main
+    - main
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -24,20 +24,20 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
-      - name: ⚙ Install prerequisites
-        run: ./init.ps1 -UpgradePrerequisites
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+    - name: ⚙ Install prerequisites
+      run: ./init.ps1 -UpgradePrerequisites
 
-      - run: dotnet docfx docfx/docfx.json
-        name: 📚 Generate documentation
+    - run: dotnet docfx docfx/docfx.json
+      name: 📚 Generate documentation
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-        with:
-          path: docfx/_site
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+      with:
+        path: docfx/_site
 
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: 📚 Docs
 on:
   push:
     branches:
-    - main
+      - main
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -24,20 +24,20 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
-    - name: ⚙ Install prerequisites
-      run: ./init.ps1 -UpgradePrerequisites
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+      - name: ⚙ Install prerequisites
+        run: ./init.ps1 -UpgradePrerequisites
 
-    - run: dotnet docfx docfx/docfx.json
-      name: 📚 Generate documentation
+      - run: dotnet docfx docfx/docfx.json
+        name: 📚 Generate documentation
 
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-      with:
-        path: docfx/_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: docfx/_site
 
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/libtemplate-update.yml
+++ b/.github/workflows/libtemplate-update.yml
@@ -7,7 +7,7 @@ name: ⛜ Library.Template update
 
 on:
   schedule:
-  - cron: "0 3 * * Mon" # Sun @ 8 or 9 PM Mountain Time (depending on DST)
+    - cron: "0 3 * * Mon" # Sun @ 8 or 9 PM Mountain Time (depending on DST)
   workflow_dispatch:
 
 jobs:
@@ -17,82 +17,82 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 
-    - name: merge
-      id: merge
-      shell: pwsh
-      run: |
-        $LibTemplateBranch = & ./tools/Get-LibTemplateBasis.ps1 -ErrorIfNotRelated
-        if ($LASTEXITCODE -ne 0) {
-          exit $LASTEXITCODE
-        }
-
-        git fetch https://github.com/aarnott/Library.Template $LibTemplateBranch
-        if ($LASTEXITCODE -ne 0) {
-          exit $LASTEXITCODE
-        }
-        $LibTemplateCommit = git rev-parse FETCH_HEAD
-        git diff --stat ...FETCH_HEAD
-
-        if ((git rev-list FETCH_HEAD ^HEAD --count) -eq 0) {
-          Write-Host "There are no Library.Template updates to merge."
-          echo "uptodate=true" >> $env:GITHUB_OUTPUT
-          exit 0
-        }
-
-        # Pushing commits that add or change files under .github/workflows will cause our workflow to fail.
-        # But it usually isn't necessary because the target branch already has (or doesn't have) these changes.
-        # So if the merge doesn't bring in any changes to these files, try the merge locally and push that
-        # to keep github happy.
-        if ((git rev-list FETCH_HEAD ^HEAD --count -- .github/workflows) -eq 0) {
-          # Indeed there are no changes in that area. So merge locally to try to appease GitHub.
-          git checkout -b auto/libtemplateUpdate
-          git config user.name "Andrew Arnott"
-          git config user.email "andrewarnott@live.com"
-          git merge FETCH_HEAD
+      - name: merge
+        id: merge
+        shell: pwsh
+        run: |
+          $LibTemplateBranch = & ./tools/Get-LibTemplateBasis.ps1 -ErrorIfNotRelated
           if ($LASTEXITCODE -ne 0) {
-            Write-Host "Merge conflicts prevent creating the pull request. Please run tools/MergeFrom-Template.ps1 locally and push the result as a pull request."
-            exit 2
+            exit $LASTEXITCODE
           }
 
-          git -c http.extraheader="AUTHORIZATION: bearer $env:GH_TOKEN" push origin -u HEAD
-        } else {
-          Write-Host "Changes to github workflows are included in this update. Please run tools/MergeFrom-Template.ps1 locally and push the result as a pull request."
-          exit 1
-        }
-    - name: pull request
-      shell: pwsh
-      if: success() && steps.merge.outputs.uptodate != 'true'
-      run: |
-        # If there is already an active pull request, don't create a new one.
-        $existingPR = gh pr list -H auto/libtemplateUpdate --json url | ConvertFrom-Json
-        if ($existingPR) {
-          Write-Host "::warning::Skipping pull request creation because one already exists at $($existingPR[0].url)"
-          exit 0
-        }
+          git fetch https://github.com/aarnott/Library.Template $LibTemplateBranch
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          $LibTemplateCommit = git rev-parse FETCH_HEAD
+          git diff --stat ...FETCH_HEAD
 
-        $prTitle = "Merge latest Library.Template"
-        $prBody = "This merges the latest features and fixes from [Library.Template's  branch](https://github.com/AArnott/Library.Template/tree/).
+          if ((git rev-list FETCH_HEAD ^HEAD --count) -eq 0) {
+            Write-Host "There are no Library.Template updates to merge."
+            echo "uptodate=true" >> $env:GITHUB_OUTPUT
+            exit 0
+          }
 
-        ⚠️ Do **not** squash this pull request when completing it. You must *merge* it.
+          # Pushing commits that add or change files under .github/workflows will cause our workflow to fail.
+          # But it usually isn't necessary because the target branch already has (or doesn't have) these changes.
+          # So if the merge doesn't bring in any changes to these files, try the merge locally and push that
+          # to keep github happy.
+          if ((git rev-list FETCH_HEAD ^HEAD --count -- .github/workflows) -eq 0) {
+            # Indeed there are no changes in that area. So merge locally to try to appease GitHub.
+            git checkout -b auto/libtemplateUpdate
+            git config user.name "Andrew Arnott"
+            git config user.email "andrewarnott@live.com"
+            git merge FETCH_HEAD
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "Merge conflicts prevent creating the pull request. Please run tools/MergeFrom-Template.ps1 locally and push the result as a pull request."
+              exit 2
+            }
 
-        <details>
-        <summary>Merge conflicts?</summary>
-        Resolve merge conflicts locally by carrying out these steps:
+            git -c http.extraheader="AUTHORIZATION: bearer $env:GH_TOKEN" push origin -u HEAD
+          } else {
+            Write-Host "Changes to github workflows are included in this update. Please run tools/MergeFrom-Template.ps1 locally and push the result as a pull request."
+            exit 1
+          }
+      - name: pull request
+        shell: pwsh
+        if: success() && steps.merge.outputs.uptodate != 'true'
+        run: |
+          # If there is already an active pull request, don't create a new one.
+          $existingPR = gh pr list -H auto/libtemplateUpdate --json url | ConvertFrom-Json
+          if ($existingPR) {
+            Write-Host "::warning::Skipping pull request creation because one already exists at $($existingPR[0].url)"
+            exit 0
+          }
 
-        ```
-        git fetch
-        git checkout auto/libtemplateUpdate
-        git merge origin/main
-        # resolve conflicts
-        git commit
-        git push
-        ```
-        </details>"
+          $prTitle = "Merge latest Library.Template"
+          $prBody = "This merges the latest features and fixes from [Library.Template's  branch](https://github.com/AArnott/Library.Template/tree/).
 
-        gh pr create -H auto/libtemplateUpdate -b $prBody -t $prTitle
-      env:
-        GH_TOKEN: ${{ github.token }}
+          ⚠️ Do **not** squash this pull request when completing it. You must *merge* it.
+
+          <details>
+          <summary>Merge conflicts?</summary>
+          Resolve merge conflicts locally by carrying out these steps:
+
+          ```
+          git fetch
+          git checkout auto/libtemplateUpdate
+          git merge origin/main
+          # resolve conflicts
+          git commit
+          git push
+          ```
+          </details>"
+
+          gh pr create -H auto/libtemplateUpdate -b $prBody -t $prTitle
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/libtemplate-update.yml
+++ b/.github/workflows/libtemplate-update.yml
@@ -7,7 +7,7 @@ name: ⛜ Library.Template update
 
 on:
   schedule:
-    - cron: "0 3 * * Mon" # Sun @ 8 or 9 PM Mountain Time (depending on DST)
+  - cron: "0 3 * * Mon" # Sun @ 8 or 9 PM Mountain Time (depending on DST)
   workflow_dispatch:
 
 jobs:
@@ -17,82 +17,82 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 
-      - name: merge
-        id: merge
-        shell: pwsh
-        run: |
-          $LibTemplateBranch = & ./tools/Get-LibTemplateBasis.ps1 -ErrorIfNotRelated
+    - name: merge
+      id: merge
+      shell: pwsh
+      run: |
+        $LibTemplateBranch = & ./tools/Get-LibTemplateBasis.ps1 -ErrorIfNotRelated
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+
+        git fetch https://github.com/aarnott/Library.Template $LibTemplateBranch
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+        $LibTemplateCommit = git rev-parse FETCH_HEAD
+        git diff --stat ...FETCH_HEAD
+
+        if ((git rev-list FETCH_HEAD ^HEAD --count) -eq 0) {
+          Write-Host "There are no Library.Template updates to merge."
+          echo "uptodate=true" >> $env:GITHUB_OUTPUT
+          exit 0
+        }
+
+        # Pushing commits that add or change files under .github/workflows will cause our workflow to fail.
+        # But it usually isn't necessary because the target branch already has (or doesn't have) these changes.
+        # So if the merge doesn't bring in any changes to these files, try the merge locally and push that
+        # to keep github happy.
+        if ((git rev-list FETCH_HEAD ^HEAD --count -- .github/workflows) -eq 0) {
+          # Indeed there are no changes in that area. So merge locally to try to appease GitHub.
+          git checkout -b auto/libtemplateUpdate
+          git config user.name "Andrew Arnott"
+          git config user.email "andrewarnott@live.com"
+          git merge FETCH_HEAD
           if ($LASTEXITCODE -ne 0) {
-            exit $LASTEXITCODE
+            Write-Host "Merge conflicts prevent creating the pull request. Please run tools/MergeFrom-Template.ps1 locally and push the result as a pull request."
+            exit 2
           }
 
-          git fetch https://github.com/aarnott/Library.Template $LibTemplateBranch
-          if ($LASTEXITCODE -ne 0) {
-            exit $LASTEXITCODE
-          }
-          $LibTemplateCommit = git rev-parse FETCH_HEAD
-          git diff --stat ...FETCH_HEAD
+          git -c http.extraheader="AUTHORIZATION: bearer $env:GH_TOKEN" push origin -u HEAD
+        } else {
+          Write-Host "Changes to github workflows are included in this update. Please run tools/MergeFrom-Template.ps1 locally and push the result as a pull request."
+          exit 1
+        }
+    - name: pull request
+      shell: pwsh
+      if: success() && steps.merge.outputs.uptodate != 'true'
+      run: |
+        # If there is already an active pull request, don't create a new one.
+        $existingPR = gh pr list -H auto/libtemplateUpdate --json url | ConvertFrom-Json
+        if ($existingPR) {
+          Write-Host "::warning::Skipping pull request creation because one already exists at $($existingPR[0].url)"
+          exit 0
+        }
 
-          if ((git rev-list FETCH_HEAD ^HEAD --count) -eq 0) {
-            Write-Host "There are no Library.Template updates to merge."
-            echo "uptodate=true" >> $env:GITHUB_OUTPUT
-            exit 0
-          }
+        $prTitle = "Merge latest Library.Template"
+        $prBody = "This merges the latest features and fixes from [Library.Template's  branch](https://github.com/AArnott/Library.Template/tree/).
 
-          # Pushing commits that add or change files under .github/workflows will cause our workflow to fail.
-          # But it usually isn't necessary because the target branch already has (or doesn't have) these changes.
-          # So if the merge doesn't bring in any changes to these files, try the merge locally and push that
-          # to keep github happy.
-          if ((git rev-list FETCH_HEAD ^HEAD --count -- .github/workflows) -eq 0) {
-            # Indeed there are no changes in that area. So merge locally to try to appease GitHub.
-            git checkout -b auto/libtemplateUpdate
-            git config user.name "Andrew Arnott"
-            git config user.email "andrewarnott@live.com"
-            git merge FETCH_HEAD
-            if ($LASTEXITCODE -ne 0) {
-              Write-Host "Merge conflicts prevent creating the pull request. Please run tools/MergeFrom-Template.ps1 locally and push the result as a pull request."
-              exit 2
-            }
+        ⚠️ Do **not** squash this pull request when completing it. You must *merge* it.
 
-            git -c http.extraheader="AUTHORIZATION: bearer $env:GH_TOKEN" push origin -u HEAD
-          } else {
-            Write-Host "Changes to github workflows are included in this update. Please run tools/MergeFrom-Template.ps1 locally and push the result as a pull request."
-            exit 1
-          }
-      - name: pull request
-        shell: pwsh
-        if: success() && steps.merge.outputs.uptodate != 'true'
-        run: |
-          # If there is already an active pull request, don't create a new one.
-          $existingPR = gh pr list -H auto/libtemplateUpdate --json url | ConvertFrom-Json
-          if ($existingPR) {
-            Write-Host "::warning::Skipping pull request creation because one already exists at $($existingPR[0].url)"
-            exit 0
-          }
+        <details>
+        <summary>Merge conflicts?</summary>
+        Resolve merge conflicts locally by carrying out these steps:
 
-          $prTitle = "Merge latest Library.Template"
-          $prBody = "This merges the latest features and fixes from [Library.Template's  branch](https://github.com/AArnott/Library.Template/tree/).
+        ```
+        git fetch
+        git checkout auto/libtemplateUpdate
+        git merge origin/main
+        # resolve conflicts
+        git commit
+        git push
+        ```
+        </details>"
 
-          ⚠️ Do **not** squash this pull request when completing it. You must *merge* it.
-
-          <details>
-          <summary>Merge conflicts?</summary>
-          Resolve merge conflicts locally by carrying out these steps:
-
-          ```
-          git fetch
-          git checkout auto/libtemplateUpdate
-          git merge origin/main
-          # resolve conflicts
-          git commit
-          git push
-          ```
-          </details>"
-
-          gh pr create -H auto/libtemplateUpdate -b $prBody -t $prTitle
-        env:
-          GH_TOKEN: ${{ github.token }}
+        gh pr create -H auto/libtemplateUpdate -b $prBody -t $prTitle
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <!-- The condition works around https://github.com/dotnet/sdk/issues/44951 -->
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.10.85" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
     <GlobalPackageReference Include="PolySharp" Version="1.16.0" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <MicrosoftTestingPlatformVersion>2.2.3</MicrosoftTestingPlatformVersion>
+    <MicrosoftTestingPlatformVersion>2.3.0</MicrosoftTestingPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Put repo-specific PackageVersion items in this group. -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <!-- Put repo-specific PackageVersion items in this group. -->
   </ItemGroup>
   <ItemGroup Label="Library.Template">
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.7.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="$(MicrosoftTestingPlatformVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingPlatformVersion)" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.Telemetry" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>

--- a/tools/GitHubActions.ps1
+++ b/tools/GitHubActions.ps1
@@ -1,0 +1,18 @@
+function Add-GitHubActionsEnvVariable {
+    param(
+        [string]$Path = $env:GITHUB_ENV,
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Name)) {
+        throw "GitHub Actions environment variable names must not be empty."
+    }
+
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    $delimiter = [guid]::NewGuid().ToString('N')
+    [System.IO.File]::AppendAllText($Path, "$Name<<$delimiter`n$Value`n$delimiter`n", $utf8NoBom)
+}

--- a/tools/GitHubActions.ps1
+++ b/tools/GitHubActions.ps1
@@ -8,6 +8,10 @@ function Add-GitHubActionsEnvVariable {
         [string]$Value
     )
 
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "GitHub Actions environment file must not be empty."
+    }
+
     if ([string]::IsNullOrWhiteSpace($Name)) {
         throw "GitHub Actions environment variable names must not be empty."
     }

--- a/tools/GitHubActions.ps1
+++ b/tools/GitHubActions.ps1
@@ -16,3 +16,18 @@ function Add-GitHubActionsEnvVariable {
     $delimiter = [guid]::NewGuid().ToString('N')
     [System.IO.File]::AppendAllText($Path, "$Name<<$delimiter`n$Value`n$delimiter`n", $utf8NoBom)
 }
+
+function Add-GitHubActionsPath {
+    param(
+        [string]$Path = $env:GITHUB_PATH,
+        [Parameter(Mandatory = $true)]
+        [string]$Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "GitHub Actions path file must not be empty."
+    }
+
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::AppendAllText($Path, "$Value`n", $utf8NoBom)
+}

--- a/tools/Set-EnvVars.ps1
+++ b/tools/Set-EnvVars.ps1
@@ -82,7 +82,7 @@ if ($PrependPath) {
             Write-Host "##vso[task.prependpath]$_"
         }
         if ($env:GITHUB_ACTIONS) {
-            Add-GitHubActionsEnvVariable -Name PATH -Value $newPathValue
+            Add-GitHubActionsPath -Value $_
         }
 
         $CmdEnvScript += "SET PATH=$_$pathDelimiter%PATH%"

--- a/tools/Set-EnvVars.ps1
+++ b/tools/Set-EnvVars.ps1
@@ -43,6 +43,18 @@ if ($env:GITHUB_ACTIONS) {
     Write-Host "GitHub Actions detected. Logging commands will be used to propagate environment variables and prepend path."
 }
 
+function Add-GitHubActionsFileCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [string]$Value
+    )
+
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::AppendAllText($Path, "$Value`n", $utf8NoBom)
+}
+
 $CmdEnvScript = ''
 $Variables.GetEnumerator() |% {
     Set-Item -LiteralPath env:$($_.Key) -Value $_.Value
@@ -52,7 +64,7 @@ $Variables.GetEnumerator() |% {
         Write-Host "##vso[task.setvariable variable=$($_.Key);]$($_.Value)"
     }
     if ($env:GITHUB_ACTIONS) {
-        Add-Content -LiteralPath $env:GITHUB_ENV -Value "$($_.Key)=$($_.Value)"
+        Add-GitHubActionsFileCommand -Path $env:GITHUB_ENV -Value "$($_.Key)=$($_.Value)"
     }
 
     if ($cmdInstructions) {
@@ -79,7 +91,7 @@ if ($PrependPath) {
             Write-Host "##vso[task.prependpath]$_"
         }
         if ($env:GITHUB_ACTIONS) {
-            Add-Content -LiteralPath $env:GITHUB_PATH -Value $_
+            Add-GitHubActionsFileCommand -Path $env:GITHUB_PATH -Value $_
         }
 
         $CmdEnvScript += "SET PATH=$_$pathDelimiter%PATH%"

--- a/tools/Set-EnvVars.ps1
+++ b/tools/Set-EnvVars.ps1
@@ -12,12 +12,14 @@
     The CmdEnvScriptPath environment variable may be optionally set to a path to a cmd shell script to be created (or appended to if it already exists) that will set the environment variables in cmd.exe that are set within the PowerShell environment.
     This is used by init.cmd in order to reapply any new environment variables to the parent cmd.exe process that were set in the powershell child process.
 #>
-[CmdletBinding(SupportsShouldProcess=$true)]
+[CmdletBinding(SupportsShouldProcess = $true)]
 Param(
-    [Parameter(Mandatory=$true, Position=1)]
+    [Parameter(Mandatory = $true, Position = 1)]
     $Variables,
     [string[]]$PrependPath
 )
+
+. "$PSScriptRoot\GitHubActions.ps1"
 
 if ($Variables.Count -eq 0) {
     return $true
@@ -27,7 +29,8 @@ $cmdInstructions = !$env:TF_BUILD -and !$env:GITHUB_ACTIONS -and !$env:CmdEnvScr
 if ($cmdInstructions) {
     Write-Warning "Environment variables have been set that will be lost because you're running under cmd.exe"
     Write-Host "Environment variables that must be set manually:" -ForegroundColor Blue
-} else {
+}
+else {
     Write-Host "Environment variables set:" -ForegroundColor Blue
     Write-Host ($Variables | Out-String)
     if ($PrependPath) {
@@ -43,28 +46,8 @@ if ($env:GITHUB_ACTIONS) {
     Write-Host "GitHub Actions detected. Logging commands will be used to propagate environment variables and prepend path."
 }
 
-function Add-GitHubActionsEnvVariable {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Path,
-        [Parameter(Mandatory = $true)]
-       [string]$Name,
-       [Parameter(Mandatory = $true)]
-       [AllowEmptyString()]
-       [string]$Value
-   )
-
-   if ([string]::IsNullOrWhiteSpace($Name)) {
-       throw "GitHub Actions environment variable names must not be empty."
-   }
-
-   $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
-   $delimiter = [guid]::NewGuid().ToString('N')
-   [System.IO.File]::AppendAllText($Path, "$Name<<$delimiter`n$Value`n$delimiter`n", $utf8NoBom)
-}
-
 $CmdEnvScript = ''
-$Variables.GetEnumerator() |% {
+$Variables.GetEnumerator() | % {
     Set-Item -LiteralPath env:$($_.Key) -Value $_.Value
 
     # If we're running in a cloud CI, set these environment variables so they propagate.
@@ -72,7 +55,7 @@ $Variables.GetEnumerator() |% {
         Write-Host "##vso[task.setvariable variable=$($_.Key);]$($_.Value)"
     }
     if ($env:GITHUB_ACTIONS) {
-        Add-GitHubActionsEnvVariable -Path $env:GITHUB_ENV -Name $_.Key -Value ([string]$_.Value)
+        Add-GitHubActionsEnvVariable -Name $_.Key -Value ([string]$_.Value)
     }
 
     if ($cmdInstructions) {
@@ -88,7 +71,7 @@ if ($IsMacOS -or $IsLinux) {
 }
 
 if ($PrependPath) {
-    $PrependPath |% {
+    $PrependPath | % {
         $newPathValue = "$_$pathDelimiter$env:PATH"
         Set-Item -LiteralPath env:PATH -Value $newPathValue
         if ($cmdInstructions) {
@@ -99,7 +82,7 @@ if ($PrependPath) {
             Write-Host "##vso[task.prependpath]$_"
         }
         if ($env:GITHUB_ACTIONS) {
-            Add-GitHubActionsEnvVariable -Path $env:GITHUB_ENV -Name PATH -Value $newPathValue
+            Add-GitHubActionsEnvVariable -Name PATH -Value $newPathValue
         }
 
         $CmdEnvScript += "SET PATH=$_$pathDelimiter%PATH%"

--- a/tools/Set-EnvVars.ps1
+++ b/tools/Set-EnvVars.ps1
@@ -43,16 +43,24 @@ if ($env:GITHUB_ACTIONS) {
     Write-Host "GitHub Actions detected. Logging commands will be used to propagate environment variables and prepend path."
 }
 
-function Add-GitHubActionsFileCommand {
+function Add-GitHubActionsEnvVariable {
     param(
         [Parameter(Mandatory = $true)]
         [string]$Path,
         [Parameter(Mandatory = $true)]
-        [string]$Value
-    )
+       [string]$Name,
+       [Parameter(Mandatory = $true)]
+       [AllowEmptyString()]
+       [string]$Value
+   )
 
-    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
-    [System.IO.File]::AppendAllText($Path, "$Value`n", $utf8NoBom)
+   if ([string]::IsNullOrWhiteSpace($Name)) {
+       throw "GitHub Actions environment variable names must not be empty."
+   }
+
+   $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+   $delimiter = [guid]::NewGuid().ToString('N')
+   [System.IO.File]::AppendAllText($Path, "$Name<<$delimiter`n$Value`n$delimiter`n", $utf8NoBom)
 }
 
 $CmdEnvScript = ''
@@ -64,7 +72,7 @@ $Variables.GetEnumerator() |% {
         Write-Host "##vso[task.setvariable variable=$($_.Key);]$($_.Value)"
     }
     if ($env:GITHUB_ACTIONS) {
-        Add-GitHubActionsFileCommand -Path $env:GITHUB_ENV -Value "$($_.Key)=$($_.Value)"
+        Add-GitHubActionsEnvVariable -Path $env:GITHUB_ENV -Name $_.Key -Value ([string]$_.Value)
     }
 
     if ($cmdInstructions) {
@@ -91,7 +99,7 @@ if ($PrependPath) {
             Write-Host "##vso[task.prependpath]$_"
         }
         if ($env:GITHUB_ACTIONS) {
-            Add-GitHubActionsFileCommand -Path $env:GITHUB_PATH -Value $_
+            Add-GitHubActionsEnvVariable -Path $env:GITHUB_ENV -Name PATH -Value $newPathValue
         }
 
         $CmdEnvScript += "SET PATH=$_$pathDelimiter%PATH%"

--- a/tools/variables/_define.ps1
+++ b/tools/variables/_define.ps1
@@ -11,7 +11,9 @@
 param (
 )
 
-. "$PSScriptRoot\..\GitHubActions.ps1"
+if ($env:GITHUB_ACTIONS) {
+    . "$PSScriptRoot\..\GitHubActions.ps1"
+}
 
 (& "$PSScriptRoot\_all.ps1").GetEnumerator() |% {
     # Always use ALL CAPS for env var names since Azure Pipelines converts variable names to all caps and on non-Windows OS, env vars are case sensitive.

--- a/tools/variables/_define.ps1
+++ b/tools/variables/_define.ps1
@@ -11,6 +11,18 @@
 param (
 )
 
+function Add-GitHubActionsFileCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [string]$Value
+    )
+
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::AppendAllText($Path, "$Value`n", $utf8NoBom)
+}
+
 (& "$PSScriptRoot\_all.ps1").GetEnumerator() |% {
     # Always use ALL CAPS for env var names since Azure Pipelines converts variable names to all caps and on non-Windows OS, env vars are case sensitive.
     $keyCaps = $_.Key.ToUpper()
@@ -24,7 +36,7 @@ param (
             # and the second that works across jobs and stages but must be fully qualified when referenced.
             Write-Host "##vso[task.setvariable variable=$keyCaps;isOutput=true]$($_.Value)"
         } elseif ($env:GITHUB_ACTIONS) {
-            Add-Content -LiteralPath $env:GITHUB_ENV -Value "$keyCaps=$($_.Value)"
+            Add-GitHubActionsFileCommand -Path $env:GITHUB_ENV -Value "$keyCaps=$($_.Value)"
         }
         Set-Item -LiteralPath "env:$keyCaps" -Value $_.Value
     }

--- a/tools/variables/_define.ps1
+++ b/tools/variables/_define.ps1
@@ -11,25 +11,7 @@
 param (
 )
 
-function Add-GitHubActionsEnvVariable {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Path,
-        [Parameter(Mandatory = $true)]
-        [string]$Name,
-        [Parameter(Mandatory = $true)]
-        [AllowEmptyString()]
-        [string]$Value
-    )
-
-    if ([string]::IsNullOrWhiteSpace($Name)) {
-        throw "GitHub Actions environment variable names must not be empty."
-    }
-
-    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
-    $delimiter = [guid]::NewGuid().ToString('N')
-    [System.IO.File]::AppendAllText($Path, "$Name<<$delimiter`n$Value`n$delimiter`n", $utf8NoBom)
-}
+. "$PSScriptRoot\..\GitHubActions.ps1"
 
 (& "$PSScriptRoot\_all.ps1").GetEnumerator() |% {
     # Always use ALL CAPS for env var names since Azure Pipelines converts variable names to all caps and on non-Windows OS, env vars are case sensitive.
@@ -44,7 +26,7 @@ function Add-GitHubActionsEnvVariable {
             # and the second that works across jobs and stages but must be fully qualified when referenced.
             Write-Host "##vso[task.setvariable variable=$keyCaps;isOutput=true]$($_.Value)"
         } elseif ($env:GITHUB_ACTIONS) {
-            Add-GitHubActionsEnvVariable -Path $env:GITHUB_ENV -Name $keyCaps -Value ([string]$_.Value)
+            Add-GitHubActionsEnvVariable -Name $keyCaps -Value ([string]$_.Value)
         }
         Set-Item -LiteralPath "env:$keyCaps" -Value $_.Value
     }

--- a/tools/variables/_define.ps1
+++ b/tools/variables/_define.ps1
@@ -11,16 +11,24 @@
 param (
 )
 
-function Add-GitHubActionsFileCommand {
+function Add-GitHubActionsEnvVariable {
     param(
         [Parameter(Mandatory = $true)]
         [string]$Path,
         [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
         [string]$Value
     )
 
+    if ([string]::IsNullOrWhiteSpace($Name)) {
+        throw "GitHub Actions environment variable names must not be empty."
+    }
+
     $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
-    [System.IO.File]::AppendAllText($Path, "$Value`n", $utf8NoBom)
+    $delimiter = [guid]::NewGuid().ToString('N')
+    [System.IO.File]::AppendAllText($Path, "$Name<<$delimiter`n$Value`n$delimiter`n", $utf8NoBom)
 }
 
 (& "$PSScriptRoot\_all.ps1").GetEnumerator() |% {
@@ -36,7 +44,7 @@ function Add-GitHubActionsFileCommand {
             # and the second that works across jobs and stages but must be fully qualified when referenced.
             Write-Host "##vso[task.setvariable variable=$keyCaps;isOutput=true]$($_.Value)"
         } elseif ($env:GITHUB_ACTIONS) {
-            Add-GitHubActionsFileCommand -Path $env:GITHUB_ENV -Value "$keyCaps=$($_.Value)"
+            Add-GitHubActionsEnvVariable -Path $env:GITHUB_ENV -Name $keyCaps -Value ([string]$_.Value)
         }
         Set-Item -LiteralPath "env:$keyCaps" -Value $_.Value
     }


### PR DESCRIPTION
This updates DotNetRepoTools with the latest Library.Template workflow and tooling changes so the repo stays aligned with current template behavior and maintenance patterns.

The merge brings in the updated GitHub workflow scripts, refreshes tool and workflow versions, and adds the shared `tools/GitHubActions.ps1` helper. The only merge conflict was in `Directory.Packages.props`; that was resolved by taking the incoming Microsoft.Testing.Platform 2.3.0 update and related template package changes while preserving this repo's existing target-framework-specific Microsoft.Build and NuGet version pins.

Please do not squash this PR when merging. This should remain a merge commit so the template sync history stays intact.

Validation completed with `dotnet restore`, `dotnet build -c Release`, and `tools/dotnet-test-cloud.ps1`.