### PR TITLE
Merge Library.Template update

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "18.9.0",
+      "version": "18.10.0",
       "commands": [
         "dotnet-coverage"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "18.10.0",
+      "version": "18.11.0",
       "commands": [
         "dotnet-coverage"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.6.4",
+      "version": "7.6.5",
       "commands": [
         "pwsh"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -31,7 +31,7 @@
       "rollForward": false
     },
     "nerdbank.dotnetrepotools": {
-      "version": "1.5.15",
+      "version": "1.5.42",
       "commands": [
         "repo"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -38,7 +38,7 @@
       "rollForward": false
     },
     "dotnet-symbol": {
-      "version": "9.0.661903",
+      "version": "10.0.731102",
       "commands": [
         "dotnet-symbol"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "nbgv": {
-      "version": "3.10.91",
+      "version": "3.10.94",
       "commands": [
         "nbgv"
       ],

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:10.0.400@sha256:e1fc6e423f543119c406d24e2e687d67c569f18f04a37a8b0005d80ad0dcee80
+FROM mcr.microsoft.com/dotnet/sdk:10.0.400@sha256:e1ffd2a92ae84c1291bc1b6887501f8af98e6331e7af6d4c8d37168c5e87a64c
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:10.0.400@sha256:e1ffd2a92ae84c1291bc1b6887501f8af98e6331e7af6d4c8d37168c5e87a64c
+FROM mcr.microsoft.com/dotnet/sdk:10.0.400@sha256:4beef5b8919dcaa2dc924233bd069257e883cc7a061e09088a97d152d6a48510
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,4 +40,4 @@ jobs:
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+      uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+
         if ('${{ inputs.ship_run_id }}') {
           $runid = '${{ inputs.ship_run_id }}'
         } else {
@@ -40,8 +43,8 @@ jobs:
 
           Write-Host "Resolved ${{ github.ref_name }} to $commitSha"
 
-          $releases = gh run list -R ${{ github.repository }} -c $commitSha -w .github/workflows/build.yml -s success --json databaseId,startedAt,event,headBranch `
-            | ConvertFrom-Json | Sort-Object startedAt -Descending
+          $releases = @(gh run list -R ${{ github.repository }} -c $commitSha -w .github/workflows/build.yml -s success --json databaseId,startedAt,event,headBranch `
+            | ConvertFrom-Json | Sort-Object startedAt -Descending)
 
           $preferredReleases = $releases | Where-Object {
             $_.event -eq 'push' -and ($_.headBranch -eq 'main' -or $_.headBranch -match '^v\d+(?:\.\d+)?$')
@@ -93,6 +96,9 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+
         Get-ChildItem '${{ runner.temp }}/deployables' -File -Recurse |% {
           Write-Host "Uploading $($_.Name) to release..."
           gh release -R ${{ github.repository }} upload "${{ github.ref_name }}" $_.FullName

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,10 @@ Having previously used `nbgv tag` and pushing the tag will help you identify the
 After publishing the release, the `.github/workflows/release.yml` workflow will be automatically triggered, which will:
 
 1. Find the most recent `.github/workflows/build.yml` GitHub workflow run of the tagged release.
-1. Upload the `deployables` artifact from that workflow run to your GitHub Release.
-1. If you have `NUGET_API_KEY` defined as a secret variable for your repo or org, any nuget packages in the `deployables` artifact will be pushed to nuget.org.
+1. Upload the `deployables-Linux` artifact from that workflow run to your GitHub Release.
+1. Any nuget packages in the `deployables-Linux` artifact will be pushed to nuget.org.
+
+The workflow is written to leverage NuGet.org Trusted Publishing.
 
 ### Azure Pipelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ After publishing the release, the `.github/workflows/release.yml` workflow will 
 1. Any nuget packages in the `deployables-Linux` artifact will be pushed to nuget.org.
 
 The workflow is written to leverage NuGet.org Trusted Publishing.
+You should set `NUGET_USER` as a repo secret to satisfy Trusted Publishing requirements.
 
 ### Azure Pipelines
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.2.19" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <!-- The condition works around https://github.com/dotnet/sdk/issues/44951 -->
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.10.91" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.10.94" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
     <GlobalPackageReference Include="PolySharp" Version="1.16.0" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <!-- Put repo-specific GlobalPackageReference items in this group. -->
   </ItemGroup>
   <ItemGroup Label="Library.Template">
-    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.2.12" />
+    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.2.19" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <!-- The condition works around https://github.com/dotnet/sdk/issues/44951 -->
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.10.91" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.Telemetry" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="$(MicrosoftTestingPlatformVersion)" />
-    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Put repo-specific GlobalPackageReference items in this group. -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <!-- Put repo-specific GlobalPackageReference items in this group. -->
   </ItemGroup>
   <ItemGroup Label="Library.Template">
-    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />
+    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.2.12" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <!-- The condition works around https://github.com/dotnet/sdk/issues/44951 -->
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.10.91" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <!-- Put repo-specific PackageVersion items in this group. -->
   </ItemGroup>
   <ItemGroup Label="Library.Template">
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.Telemetry" Version="$(MicrosoftTestingPlatformVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,13 +4,13 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <MicrosoftTestingPlatformVersion>2.3.3</MicrosoftTestingPlatformVersion>
+    <MicrosoftTestingPlatformVersion>2.4.0</MicrosoftTestingPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Put repo-specific PackageVersion items in this group. -->
   </ItemGroup>
   <ItemGroup Label="Library.Template">
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.Telemetry" Version="$(MicrosoftTestingPlatformVersion)" />

--- a/tools/dotnet-test-cloud.ps1
+++ b/tools/dotnet-test-cloud.ps1
@@ -43,7 +43,7 @@ if ($x86) {
       Write-Host "Running tests using `"$dotnet`"" -ForegroundColor DarkGray
     } else {
       Write-Error "Unable to find 32-bit dotnet.exe"
-      return 1
+      exit 1
     }
   }
 }

--- a/tools/dotnet-test-cloud.ps1
+++ b/tools/dotnet-test-cloud.ps1
@@ -61,7 +61,7 @@ if ($isMTP) {
 
     $dumpSwitches = @(
         ,'--hangdump'
-        ,'--hangdump-timeout','120s'
+        ,'--hangdump-timeout','5m'
         ,'--crashdump'
         ,'--crashdump-type','Heap'
         # The native crash report accompanies the dump and is often the only way to identify the
@@ -84,10 +84,17 @@ if ($isMTP) {
         )
     }
 
-    & $dotnet test --solution $RepoRoot `
+    $solutionFiles = @(Get-ChildItem -LiteralPath $RepoRoot -File | Where-Object { $_.Extension -in '.sln', '.slnx' })
+    if ($solutionFiles.Count -ne 1) {
+        throw "Expected exactly one solution file in $RepoRoot, but found $($solutionFiles.Count)."
+    }
+
+    $solutionPath = $solutionFiles[0].FullName
+    & $dotnet test $solutionPath `
         --no-build `
         -c $Configuration `
         -bl:"$testBinLog" `
+        -- `
         --filter-not-trait 'TestCategory=FailsInCloudTest' `
         @mtpArgs `
         @dumpSwitches `

--- a/tools/publish-CodeCov.ps1
+++ b/tools/publish-CodeCov.ps1
@@ -22,30 +22,34 @@ Param (
 
 $RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
 $codeCovTool = & "$PSScriptRoot/Get-CodeCovTool.ps1"
+$coverageFiles = @(Get-ChildItem -Recurse -LiteralPath $PathToCodeCoverage -Filter "*.cobertura.xml")
+if ($coverageFiles.Count -eq 0) {
+    return
+}
 
-Get-ChildItem -Recurse -LiteralPath $PathToCodeCoverage -Filter "*.cobertura.xml" | % {
-    $relativeFilePath = Resolve-Path -relative $_.FullName
-
+$arguments = @(
+    "upload-process",
+    "--disable-search",
+    "--fail-on-error",
+    "-t", $CodeCovToken,
+    "--network-root-folder", $RepoRoot
+)
+foreach ($coverageFile in $coverageFiles) {
+    $relativeFilePath = Resolve-Path -Relative $coverageFile.FullName
     Write-Host "Uploading: $relativeFilePath" -ForegroundColor Yellow
-    $arguments = @(
-        "upload-process",
-        "--disable-search",
-        "--fail-on-error",
-        "-t", $CodeCovToken,
-        "-f", $relativeFilePath,
-        "--network-root-folder", $RepoRoot
-    )
-    if ($Flags) {
-        $arguments += @("-F", $Flags)
-    }
+    $arguments += @("-f", $relativeFilePath)
+}
 
-    if ($Name) {
-        $arguments += @("-n", $Name)
-    }
+if ($Flags) {
+    $arguments += @("-F", $Flags)
+}
 
-    & $codeCovTool @arguments
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Codecov CLI failed with exit code $LASTEXITCODE."
-        exit $LASTEXITCODE
-    }
+if ($Name) {
+    $arguments += @("-n", $Name)
+}
+
+& $codeCovTool @arguments
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Codecov CLI failed with exit code $LASTEXITCODE."
+    exit $LASTEXITCODE
 }

--- a/tools/publish-CodeCov.ps1
+++ b/tools/publish-CodeCov.ps1
@@ -43,7 +43,7 @@ Get-ChildItem -Recurse -LiteralPath $PathToCodeCoverage -Filter "*.cobertura.xml
         $arguments += @("-n", $Name)
     }
 
-    & $codeCovTool $arguments
+    & $codeCovTool @arguments
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Codecov CLI failed with exit code $LASTEXITCODE."
         exit $LASTEXITCODE


### PR DESCRIPTION
## Summary

This PR merges the latest Library.Template updates into the repository and keeps the repo aligned with the current template baseline.

Specifically, this merges [916a180 from Library.Template](https://github.com/aarnott/Library.Template/commit/916a18028aeb287efbd62492b2dd04819881a1aa).

⚠️ Do **not** squash this pull request when completing it. You must *merge* it.

## Why

Updating from the template brings in the latest build, test, and workflow improvements, while also keeping the repo's packaging and CI configuration current.

## What changed

- Merged the template updates from Library.Template.
- Resolved the `Directory.Packages.props` conflict by keeping the repo's existing MicrosoftBuild/NuGet version properties while adopting the template's `MicrosoftTestingPlatformVersion` 2.4.0.
- Updated workflow, SDK, and tooling files to match the new template baseline, including:
  - Microsoft Testing Platform 2.4.0 and xunit.v3.mtp-v2 4.0.0
  - Microsoft.Testing.Extensions.CodeCoverage and dotnet-coverage 18.11.0
  - nbgv / Nerdbank.GitVersioning 3.10.94
  - CSharpIsNullAnalyzer 0.2.19
  - PowerShell 7.6.5, dotnet-symbol v10, and the .NET SDK Docker digest
  - Release workflow error handling and CONTRIBUTING notes for Trusted Publishing
  - Test and code coverage script improvements (`dotnet-test-cloud.ps1`, `publish-CodeCov.ps1`)

## Validation

- `dotnet restore`
- `dotnet build -t:build,pack --no-restore -c Release -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904`
- `./tools/dotnet-test-cloud.ps1 -Configuration Release` (144 passed, 0 failed, 0 skipped)