### PR TITLE
Detect target frameworks for NuGet commands

### DIFF
--- a/src/Nerdbank.DotNetRepoTools/MSBuild.cs
+++ b/src/Nerdbank.DotNetRepoTools/MSBuild.cs
@@ -144,20 +144,6 @@ public class MSBuild : IDisposable
 		return effectiveProperties;
 	}
 
-	internal Project EvaluateProject(string projectFile, string targetFramework, ProjectLoadSettings projectLoadSettings)
-	{
-		string fullPath = Path.GetFullPath(projectFile);
-		Project? loadedProject = this.ProjectCollection.GetLoadedProjects(fullPath).FirstOrDefault(project =>
-			project.GlobalProperties.TryGetValue("TargetFramework", out string? loadedTargetFramework) &&
-			string.Equals(loadedTargetFramework, targetFramework, StringComparison.OrdinalIgnoreCase));
-		return loadedProject ?? new Project(
-			fullPath,
-			this.CreateEvaluationProperties(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["TargetFramework"] = targetFramework }),
-			toolsVersion: null,
-			this.ProjectCollection,
-			projectLoadSettings);
-	}
-
 	/// <summary>
 	/// Synthesizes a project in memory, under some path.
 	/// </summary>

--- a/src/Nerdbank.DotNetRepoTools/MSBuild.cs
+++ b/src/Nerdbank.DotNetRepoTools/MSBuild.cs
@@ -144,6 +144,20 @@ public class MSBuild : IDisposable
 		return effectiveProperties;
 	}
 
+	internal Project EvaluateProject(string projectFile, string targetFramework, ProjectLoadSettings projectLoadSettings)
+	{
+		string fullPath = Path.GetFullPath(projectFile);
+		Project? loadedProject = this.ProjectCollection.GetLoadedProjects(fullPath).FirstOrDefault(project =>
+			project.GlobalProperties.TryGetValue("TargetFramework", out string? loadedTargetFramework) &&
+			string.Equals(loadedTargetFramework, targetFramework, StringComparison.OrdinalIgnoreCase));
+		return loadedProject ?? new Project(
+			fullPath,
+			this.CreateEvaluationProperties(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["TargetFramework"] = targetFramework }),
+			toolsVersion: null,
+			this.ProjectCollection,
+			projectLoadSettings);
+	}
+
 	/// <summary>
 	/// Synthesizes a project in memory, under some path.
 	/// </summary>

--- a/src/Nerdbank.DotNetRepoTools/NuGet/NuGetHelper.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/NuGetHelper.cs
@@ -191,6 +191,12 @@ internal class NuGetHelper
 							nameOfChangedProperty = propertyName;
 						}
 					}
+
+					if (fixesApplied)
+					{
+						this.msbuild.SaveAll();
+						this.msbuild.ReloadEverything();
+					}
 				}
 
 				if (nameOfChangedProperty is null)

--- a/src/Nerdbank.DotNetRepoTools/NuGet/NuGetHelper.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/NuGetHelper.cs
@@ -228,47 +228,22 @@ internal class NuGetHelper
 			this.Out.WriteLine("Looking for package downgrade issues...");
 
 			this.Project.ReevaluateIfNecessary();
+			List<PackageReference> packageReferences = this.Project.GetItems(PackageVersionItemType)
+				.SelectMany(packageVersion => targetFrameworks.Select(framework => this.CreatePackageReference(packageVersion.EvaluatedInclude, packageVersion.GetMetadataValue(VersionMetadata), framework))).ToList();
 			fixesApplied = false;
-			foreach (NuGetFramework targetFramework in targetFrameworks)
+			IReadOnlyList<RestoreTargetGraph> restoreGraphs = await this.GetRestoreTargetGraphsAsync(packageReferences, [.. targetFrameworks], cancellationToken, suppressSyntheticCompatibilityErrors: true);
+			foreach (DowngradeResult<RemoteResolveResult> conflict in restoreGraphs.SelectMany(graph => graph.AnalyzeResult.Downgrades))
 			{
-				List<PackageReference> packageReferences = this.GetPackageVersionItems(targetFramework)
-					.Select(packageVersion => (PackageId: packageVersion.EvaluatedInclude, Version: packageVersion.GetMetadataValue(VersionMetadata)))
-					.Where(packageVersion => packageVersion.Version.Length > 0)
-					.Select(packageVersion => this.CreatePackageReference(packageVersion.PackageId, packageVersion.Version, targetFramework))
-					.ToList();
-				IReadOnlyList<RestoreTargetGraph> restoreGraphs = await this.GetRestoreTargetGraphsAsync(packageReferences, [targetFramework], cancellationToken, suppressSyntheticCompatibilityErrors: true);
-				foreach (DowngradeResult<RemoteResolveResult> conflict in restoreGraphs.SelectMany(graph => graph.AnalyzeResult.Downgrades))
+				if (conflict.DowngradedFrom.Key.VersionRange?.OriginalString is string originalVersion &&
+					this.SetPackageVersion(conflict.DowngradedFrom.Key.Name, originalVersion, disregardVersionProperties: disregardVersionProperties))
 				{
-					if (conflict.DowngradedFrom.Key.VersionRange?.OriginalString is string originalVersion &&
-						this.SetPackageVersion(conflict.DowngradedFrom.Key.Name, originalVersion, disregardVersionProperties: disregardVersionProperties))
-					{
-						fixesApplied = true;
-						versionsUpdated++;
-					}
-				}
-
-				if (fixesApplied)
-				{
-					this.msbuild.SaveAll();
-					this.msbuild.ReloadEverything();
+					fixesApplied = true;
+					versionsUpdated++;
 				}
 			}
 		}
 
 		return versionsUpdated;
-	}
-
-	internal IEnumerable<ProjectItem> GetPackageVersionItems(NuGetFramework targetFramework)
-	{
-		ProjectRootElement directoryPackagesProps = this.Project.Imports
-			.FirstOrDefault(import => string.Equals(Path.GetFileName(import.ImportedProject.FullPath), "Directory.Packages.props", StringComparison.OrdinalIgnoreCase))
-			.ImportedProject
-			?? throw new InvalidOperationException("Unable to find an imported Directory.Packages.props.");
-		Project project = this.msbuild.EvaluateProject(
-			directoryPackagesProps.FullPath,
-			targetFramework.GetShortFolderName(),
-			ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreInvalidImports);
-		return project.GetItems(PackageVersionItemType);
 	}
 
 	private static Project OpenOrCreateSandboxProject(MSBuild msbuild, string path)

--- a/src/Nerdbank.DotNetRepoTools/NuGet/NuGetHelper.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/NuGetHelper.cs
@@ -77,7 +77,7 @@ internal class NuGetHelper
 		return new PackageReference(new PackageIdentity(id, null), nugetFramework, userInstalled: true, developmentDependency: false, requireReinstallation: false, VersionRange.Parse(version));
 	}
 
-	internal async Task<RestoreTargetGraph> GetRestoreTargetGraphAsync(IReadOnlyCollection<PackageReference> packages, List<NuGetFramework> targetFrameworks, CancellationToken cancellationToken)
+	internal async Task<IReadOnlyList<RestoreTargetGraph>> GetRestoreTargetGraphsAsync(IReadOnlyCollection<PackageReference> packages, List<NuGetFramework> targetFrameworks, CancellationToken cancellationToken, bool suppressSyntheticCompatibilityErrors = false)
 	{
 		PackageSpec packageSpec = GetPackageSpec(this.Project.FullPath, this.NuGetSettings, packages, targetFrameworks) ?? throw new InvalidOperationException("Unable to generate a package spec for this project.");
 		packageSpec.RestoreMetadata.PackagesPath = SettingsUtility.GetGlobalPackagesFolder(this.NuGetSettings);
@@ -118,23 +118,23 @@ internal class NuGetHelper
 		IReadOnlyList<RestoreResultPair> restoreResult = await RestoreRunner.RunWithoutCommit(requests, restoreArgs);
 
 		RestoreResult restoreResultResult = restoreResult[0].Result;
-		RestoreTargetGraph restoreTargetGraph = restoreResultResult.RestoreGraphs.First();
 
 		foreach (IAssetsLogMessage message in restoreResultResult.LogMessages)
 		{
-			if (!message.Message.StartsWith("Invalid project-package combination for ", StringComparison.Ordinal) &&
-				!(message.Message.StartsWith("Package ", StringComparison.Ordinal) && message.Message.Contains(" is not compatible with ", StringComparison.Ordinal)))
+			if (!suppressSyntheticCompatibilityErrors ||
+				(!message.Message.StartsWith("Invalid project-package combination for ", StringComparison.Ordinal) &&
+				!(message.Message.StartsWith("Package ", StringComparison.Ordinal) && message.Message.Contains(" is not compatible with ", StringComparison.Ordinal))))
 			{
 				this.Error.WriteLine($"{message.Message}");
 			}
 		}
 
-		foreach (LibraryRange issue in restoreTargetGraph.Unresolved)
+		foreach (LibraryRange issue in restoreResultResult.RestoreGraphs.SelectMany(graph => graph.Unresolved))
 		{
 			this.Error.WriteLine($"Unresolved package: {issue.Name} {issue.VersionRange}");
 		}
 
-		return restoreTargetGraph;
+		return restoreResultResult.RestoreGraphs.ToList();
 	}
 
 	internal bool SetPackageVersion(string id, string version, bool addIfMissing = true, bool allowDowngrade = true, HashSet<string>? disregardVersionProperties = null)
@@ -228,23 +228,41 @@ internal class NuGetHelper
 			this.Out.WriteLine("Looking for package downgrade issues...");
 
 			this.Project.ReevaluateIfNecessary();
-			List<PackageReference> packageReferences = this.Project.GetItems(PackageVersionItemType)
-				.SelectMany(pv => targetFrameworks.Select(framework => this.CreatePackageReference(pv.EvaluatedInclude, pv.GetMetadataValue(VersionMetadata), framework))).ToList();
-
 			fixesApplied = false;
-			RestoreTargetGraph restoreGraph = await this.GetRestoreTargetGraphAsync(packageReferences, [.. targetFrameworks], cancellationToken);
-			foreach (DowngradeResult<RemoteResolveResult> conflict in restoreGraph.AnalyzeResult.Downgrades)
+			foreach (NuGetFramework targetFramework in targetFrameworks)
 			{
-				if (conflict.DowngradedFrom.Key.VersionRange?.OriginalString is string originalVersion &&
-					this.SetPackageVersion(conflict.DowngradedFrom.Key.Name, originalVersion, disregardVersionProperties: disregardVersionProperties))
+				List<PackageReference> packageReferences = this.GetPackageVersionItems(targetFramework)
+					.Select(packageVersion => (PackageId: packageVersion.EvaluatedInclude, Version: packageVersion.GetMetadataValue(VersionMetadata)))
+					.Where(packageVersion => packageVersion.Version.Length > 0)
+					.Select(packageVersion => this.CreatePackageReference(packageVersion.PackageId, packageVersion.Version, targetFramework))
+					.ToList();
+				IReadOnlyList<RestoreTargetGraph> restoreGraphs = await this.GetRestoreTargetGraphsAsync(packageReferences, [targetFramework], cancellationToken, suppressSyntheticCompatibilityErrors: true);
+				foreach (DowngradeResult<RemoteResolveResult> conflict in restoreGraphs.SelectMany(graph => graph.AnalyzeResult.Downgrades))
 				{
-					fixesApplied = true;
-					versionsUpdated++;
+					if (conflict.DowngradedFrom.Key.VersionRange?.OriginalString is string originalVersion &&
+						this.SetPackageVersion(conflict.DowngradedFrom.Key.Name, originalVersion, disregardVersionProperties: disregardVersionProperties))
+					{
+						fixesApplied = true;
+						versionsUpdated++;
+					}
 				}
 			}
 		}
 
 		return versionsUpdated;
+	}
+
+	internal IEnumerable<ProjectItem> GetPackageVersionItems(NuGetFramework targetFramework)
+	{
+		ProjectRootElement directoryPackagesProps = this.Project.Imports
+			.FirstOrDefault(import => string.Equals(Path.GetFileName(import.ImportedProject.FullPath), "Directory.Packages.props", StringComparison.OrdinalIgnoreCase))
+			.ImportedProject
+			?? throw new InvalidOperationException("Unable to find an imported Directory.Packages.props.");
+		Project project = this.msbuild.EvaluateProject(
+			directoryPackagesProps.FullPath,
+			targetFramework.GetShortFolderName(),
+			ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreInvalidImports);
+		return project.GetItems(PackageVersionItemType);
 	}
 
 	private static Project OpenOrCreateSandboxProject(MSBuild msbuild, string path)

--- a/src/Nerdbank.DotNetRepoTools/NuGet/NuGetHelper.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/NuGetHelper.cs
@@ -122,7 +122,11 @@ internal class NuGetHelper
 
 		foreach (IAssetsLogMessage message in restoreResultResult.LogMessages)
 		{
-			this.Error.WriteLine($"{message.Message}");
+			if (!message.Message.StartsWith("Invalid project-package combination for ", StringComparison.Ordinal) &&
+				!(message.Message.StartsWith("Package ", StringComparison.Ordinal) && message.Message.Contains(" is not compatible with ", StringComparison.Ordinal)))
+			{
+				this.Error.WriteLine($"{message.Message}");
+			}
 		}
 
 		foreach (LibraryRange issue in restoreTargetGraph.Unresolved)
@@ -213,7 +217,7 @@ internal class NuGetHelper
 		return changed;
 	}
 
-	internal async Task<int> CorrectDowngradeIssuesAsync(NuGetFramework framework, PackageReference? hypotheticalPackageReference, HashSet<string>? disregardVersionProperties, CancellationToken cancellationToken)
+	internal async Task<int> CorrectDowngradeIssuesAsync(IReadOnlyList<NuGetFramework> targetFrameworks, HashSet<string>? disregardVersionProperties, CancellationToken cancellationToken)
 	{
 		int versionsUpdated = 0;
 		bool fixesApplied = true;
@@ -225,16 +229,10 @@ internal class NuGetHelper
 
 			this.Project.ReevaluateIfNecessary();
 			List<PackageReference> packageReferences = this.Project.GetItems(PackageVersionItemType)
-				.Select(pv => this.CreatePackageReference(pv.EvaluatedInclude, pv.GetMetadataValue(VersionMetadata), framework)).ToList();
-
-			if (hypotheticalPackageReference is not null)
-			{
-				packageReferences.Add(hypotheticalPackageReference);
-			}
-
-			RestoreTargetGraph restoreGraph = await this.GetRestoreTargetGraphAsync(packageReferences, new() { framework }, cancellationToken);
+				.SelectMany(pv => targetFrameworks.Select(framework => this.CreatePackageReference(pv.EvaluatedInclude, pv.GetMetadataValue(VersionMetadata), framework))).ToList();
 
 			fixesApplied = false;
+			RestoreTargetGraph restoreGraph = await this.GetRestoreTargetGraphAsync(packageReferences, [.. targetFrameworks], cancellationToken);
 			foreach (DowngradeResult<RemoteResolveResult> conflict in restoreGraph.AnalyzeResult.Downgrades)
 			{
 				if (conflict.DowngradedFrom.Key.VersionRange?.OriginalString is string originalVersion &&

--- a/src/Nerdbank.DotNetRepoTools/NuGet/NuGetHelper.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/NuGetHelper.cs
@@ -192,11 +192,6 @@ internal class NuGetHelper
 						}
 					}
 
-					if (fixesApplied)
-					{
-						this.msbuild.SaveAll();
-						this.msbuild.ReloadEverything();
-					}
 				}
 
 				if (nameOfChangedProperty is null)
@@ -251,6 +246,12 @@ internal class NuGetHelper
 						fixesApplied = true;
 						versionsUpdated++;
 					}
+				}
+
+				if (fixesApplied)
+				{
+					this.msbuild.SaveAll();
+					this.msbuild.ReloadEverything();
 				}
 			}
 		}

--- a/src/Nerdbank.DotNetRepoTools/NuGet/NuGetHelper.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/NuGetHelper.cs
@@ -191,7 +191,6 @@ internal class NuGetHelper
 							nameOfChangedProperty = propertyName;
 						}
 					}
-
 				}
 
 				if (nameOfChangedProperty is null)

--- a/src/Nerdbank.DotNetRepoTools/NuGet/ReconcileVersionsCommand.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/ReconcileVersionsCommand.cs
@@ -34,7 +34,12 @@ public class ReconcileVersionsCommand : MSBuildCommandBase
 	/// <summary>
 	/// Gets the target framework used to evaluate package dependencies.
 	/// </summary>
-	public required string TargetFramework { get; init; }
+	public string? TargetFramework { get; init; }
+
+	/// <summary>
+	/// Gets the target frameworks used to evaluate package dependencies.
+	/// </summary>
+	public IReadOnlyList<string>? TargetFrameworks { get; init; }
 
 	/// <summary>
 	/// Gets the set of version properties to disregard when updating package versions that were previously defined by properties.
@@ -48,7 +53,7 @@ public class ReconcileVersionsCommand : MSBuildCommandBase
 	internal static Command CreateCommand()
 	{
 		Option<FileSystemInfo> pathOption = new Option<FileSystemInfo>("--path") { Description = "The path to the project or repo to resolve version issues with." }.AcceptExistingOnly();
-		Option<string> frameworkOption = new Option<string>("--framework", "-f") { DefaultValueFactory = _ => "netstandard2.0", Description = "The target framework used to evaluate package dependencies." };
+		Option<string[]> frameworkOption = new Option<string[]>("--framework", "-f") { Description = "The target frameworks used to evaluate package dependencies.", AllowMultipleArgumentsPerToken = true };
 		Option<string[]> disregardVersionPropertiesOption = new("--disregard-version-properties") { Description = "Specifies one or more MSBuild properties that may be used to define a PackageVersion item's Version attribute that should no longer be referenced. This may be useful when properties have been used for multiple packages and their continued use is problematic because the packages now need their own distinct versions.", AllowMultipleArgumentsPerToken = true };
 
 		Command command = new("reconcile-versions", "Resolves all package downgrade warnings.")
@@ -60,7 +65,7 @@ public class ReconcileVersionsCommand : MSBuildCommandBase
 		command.SetAction((parseResult, cancellationToken) => new ReconcileVersionsCommand(parseResult, cancellationToken)
 		{
 			ProjectPath = parseResult.GetValue(pathOption)?.FullName ?? Environment.CurrentDirectory,
-			TargetFramework = parseResult.GetValue(frameworkOption)!,
+			TargetFrameworks = parseResult.GetValue(frameworkOption),
 			DisregardVersionProperties = parseResult.GetValue(disregardVersionPropertiesOption)?.ToHashSet(StringComparer.OrdinalIgnoreCase),
 		}.ExecuteAndDisposeAsync());
 
@@ -72,8 +77,8 @@ public class ReconcileVersionsCommand : MSBuildCommandBase
 	{
 		NuGetHelper nuget = new(this.MSBuild, this.ProjectPath) { Out = this.Out, Error = this.Error };
 
-		NuGetFramework nugetFramework = NuGetFramework.Parse(this.TargetFramework);
-		int versionsUpdated = await nuget.CorrectDowngradeIssuesAsync(nugetFramework, null, this.DisregardVersionProperties, this.CancellationToken);
+		IReadOnlyList<NuGetFramework> targetFrameworks = TargetFrameworkResolver.Resolve(this.MSBuild, this.ProjectPath, this.TargetFrameworks ?? (this.TargetFramework is null ? null : [this.TargetFramework]));
+		int versionsUpdated = await nuget.CorrectDowngradeIssuesAsync(targetFrameworks, this.DisregardVersionProperties, this.CancellationToken);
 		this.Out.WriteLine($"All done. {versionsUpdated} package versions were updated.");
 	}
 }

--- a/src/Nerdbank.DotNetRepoTools/NuGet/TargetFrameworkResolver.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/TargetFrameworkResolver.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft;
+using Microsoft.Build.Evaluation;
+using NuGet.Frameworks;
+
+namespace Nerdbank.DotNetRepoTools.NuGet;
+
+/// <summary>
+/// Resolves the target frameworks used by NuGet maintenance commands.
+/// </summary>
+internal static class TargetFrameworkResolver
+{
+	/// <summary>
+	/// Resolves explicitly requested frameworks or discovers them from projects under a path.
+	/// </summary>
+	/// <param name="msbuild">The MSBuild instance used to evaluate projects.</param>
+	/// <param name="path">The project file or directory to inspect.</param>
+	/// <param name="requestedFrameworks">The explicitly requested frameworks, if any.</param>
+	/// <returns>The distinct resolved frameworks.</returns>
+	/// <exception cref="InvalidOperationException">Thrown when no target frameworks can be determined.</exception>
+	internal static IReadOnlyList<NuGetFramework> Resolve(MSBuild msbuild, string path, IReadOnlyList<string>? requestedFrameworks)
+	{
+		Requires.NotNull(msbuild);
+		Requires.NotNullOrEmpty(path);
+
+		IEnumerable<string> frameworkNames = requestedFrameworks is { Count: > 0 }
+			? requestedFrameworks
+			: GetProjectPaths(path)
+				.SelectMany(projectPath =>
+				{
+					Project project = msbuild.GetProject(projectPath, ProjectLoadSettings.IgnoreMissingImports);
+					string targetFrameworks = project.GetPropertyValue("TargetFrameworks");
+					return targetFrameworks.Length > 0 ? targetFrameworks.Split(';') : [project.GetPropertyValue("TargetFramework")];
+				});
+
+		HashSet<NuGetFramework> targetFrameworks = new(NuGetFramework.Comparer);
+		foreach (string frameworkName in frameworkNames.SelectMany(framework => framework.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)))
+		{
+			targetFrameworks.Add(NuGetFramework.Parse(frameworkName));
+		}
+
+		if (targetFrameworks.Count == 0)
+		{
+			throw new InvalidOperationException($"Unable to determine target frameworks from '{path}'. Specify at least one with --framework.");
+		}
+
+		return [.. targetFrameworks];
+	}
+
+	private static IEnumerable<string> GetProjectPaths(string path)
+	{
+		return File.Exists(path)
+			? [path]
+			: Directory.EnumerateFiles(path, "*.*proj", SearchOption.AllDirectories);
+	}
+}

--- a/src/Nerdbank.DotNetRepoTools/NuGet/UpgradeCommand.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/UpgradeCommand.cs
@@ -129,9 +129,11 @@ public class UpgradeCommand : MSBuildCommandBase
 		this.CancellationToken.ThrowIfCancellationRequested();
 
 		this.Out.WriteLine("Proactively resolving any introduced package downgrade issues in dependencies.");
-		RestoreTargetGraph restoreGraph = await nuget.GetRestoreTargetGraphAsync(topLevelReferences, [.. targetFrameworks], this.CancellationToken);
-		Dictionary<string, DowngradeResult<RemoteResolveResult>> downgrades = restoreGraph.AnalyzeResult.Downgrades.ToDictionary(r => r.DowngradedTo.Key.Name, StringComparer.OrdinalIgnoreCase);
-		foreach (GraphItem<RemoteResolveResult>? item in restoreGraph.Flattened.Where(i => i.Key.Type == LibraryType.Package))
+		IReadOnlyList<RestoreTargetGraph> restoreGraphs = await nuget.GetRestoreTargetGraphsAsync(topLevelReferences, [.. targetFrameworks], this.CancellationToken);
+		Dictionary<string, DowngradeResult<RemoteResolveResult>> downgrades = restoreGraphs.SelectMany(graph => graph.AnalyzeResult.Downgrades)
+			.GroupBy(result => result.DowngradedTo.Key.Name, StringComparer.OrdinalIgnoreCase)
+			.ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+		foreach (GraphItem<RemoteResolveResult>? item in restoreGraphs.SelectMany(graph => graph.Flattened).Where(i => i.Key.Type == LibraryType.Package))
 		{
 			string version = downgrades.TryGetValue(item.Key.Name, out DowngradeResult<RemoteResolveResult>? downgrade)
 				? downgrade.DowngradedFrom.Item.Key.Version.ToFullString()

--- a/src/Nerdbank.DotNetRepoTools/NuGet/UpgradeCommand.cs
+++ b/src/Nerdbank.DotNetRepoTools/NuGet/UpgradeCommand.cs
@@ -48,7 +48,12 @@ public class UpgradeCommand : MSBuildCommandBase
 	/// <summary>
 	/// Gets the target framework used to evaluate package dependencies.
 	/// </summary>
-	public required string TargetFramework { get; init; }
+	public string? TargetFramework { get; init; }
+
+	/// <summary>
+	/// Gets the target frameworks used to evaluate package dependencies.
+	/// </summary>
+	public IReadOnlyList<string>? TargetFrameworks { get; init; }
 
 	/// <summary>
 	/// Gets a value indicating whether all transitive dependencies will be explicitly added (not just updated as needed if they exist).
@@ -69,7 +74,7 @@ public class UpgradeCommand : MSBuildCommandBase
 		Argument<string> packageIdArgument = new Argument<string>("id") { Description = "The ID of the root package to be upgraded." };
 		Argument<string> packageVersionArgument = new Argument<string>("version") { Description = "The version to upgrade to." };
 		Option<FileSystemInfo> pathOption = new Option<FileSystemInfo>("--path") { Description = "The path to the project or repo to upgrade.", Required = !File.Exists(DirectoryPackagesPropsFileName) }.AcceptExistingOnly();
-		Option<string> frameworkOption = new Option<string>("--framework", "-f") { Description = "The target framework used to evaluate package dependencies.", DefaultValueFactory = _ => "netstandard2.0" };
+		Option<string[]> frameworkOption = new Option<string[]>("--framework", "-f") { Description = "The target frameworks used to evaluate package dependencies.", AllowMultipleArgumentsPerToken = true };
 		Option<bool> explodeOption = new("--explode") { Description = "Add PackageVersion items for every transitive dependency, so that they can be added as direct project dependencies as versions are pre-specified." };
 		Option<string[]> disregardVersionPropertiesOption = new("--disregard-version-properties") { Description = "Specifies one or more MSBuild properties that may be used to define a PackageVersion item's Version attribute that should no longer be referenced. This may be useful when properties have been used for multiple packages and their continued use is problematic because the packages now need their own distinct versions.", AllowMultipleArgumentsPerToken = true };
 
@@ -87,7 +92,7 @@ public class UpgradeCommand : MSBuildCommandBase
 			PackageId = parseResult.GetValue(packageIdArgument)!,
 			PackageVersion = parseResult.GetValue(packageVersionArgument)!,
 			Path = parseResult.GetValue(pathOption)?.FullName ?? Environment.CurrentDirectory,
-			TargetFramework = parseResult.GetValue(frameworkOption)!,
+			TargetFrameworks = parseResult.GetValue(frameworkOption),
 			Explode = parseResult.GetValue(explodeOption),
 			DisregardVersionProperties = parseResult.GetValue(disregardVersionPropertiesOption)?.ToHashSet(StringComparer.OrdinalIgnoreCase),
 		}.ExecuteAndDisposeAsync());
@@ -117,15 +122,14 @@ public class UpgradeCommand : MSBuildCommandBase
 			nuget.Project.ReevaluateIfNecessary();
 		}
 
-		NuGetFramework nugetFramework = NuGetFramework.Parse(this.TargetFramework);
-		List<NuGetFramework> targetFrameworks = new() { nugetFramework };
-		PackageReference topLevelReference = nuget.CreatePackageReference(this.PackageId, this.PackageVersion, nugetFramework);
+		IReadOnlyList<NuGetFramework> targetFrameworks = TargetFrameworkResolver.Resolve(this.MSBuild, this.Path, this.TargetFrameworks ?? (this.TargetFramework is null ? null : [this.TargetFramework]));
+		PackageReference[] topLevelReferences = [.. targetFrameworks.Select(framework => nuget.CreatePackageReference(this.PackageId, this.PackageVersion, framework))];
 
 		// Visit every transitive dependency and explicitly set it.
 		this.CancellationToken.ThrowIfCancellationRequested();
 
 		this.Out.WriteLine("Proactively resolving any introduced package downgrade issues in dependencies.");
-		RestoreTargetGraph restoreGraph = await nuget.GetRestoreTargetGraphAsync(new[] { topLevelReference }, targetFrameworks, this.CancellationToken);
+		RestoreTargetGraph restoreGraph = await nuget.GetRestoreTargetGraphAsync(topLevelReferences, [.. targetFrameworks], this.CancellationToken);
 		Dictionary<string, DowngradeResult<RemoteResolveResult>> downgrades = restoreGraph.AnalyzeResult.Downgrades.ToDictionary(r => r.DowngradedTo.Key.Name, StringComparer.OrdinalIgnoreCase);
 		foreach (GraphItem<RemoteResolveResult>? item in restoreGraph.Flattened.Where(i => i.Key.Type == LibraryType.Package))
 		{

--- a/test/Nerdbank.DotNetRepoTools.Tests/NuGet/ReconcileVersionsCommandTests.cs
+++ b/test/Nerdbank.DotNetRepoTools.Tests/NuGet/ReconcileVersionsCommandTests.cs
@@ -20,6 +20,10 @@ public class ReconcileVersionsCommandTests : CommandTestBase<ReconcileVersionsCo
 		await base.InitializeAsync();
 
 		await this.SynthesizeAllMSBuildAssetsAsync();
+		await File.WriteAllTextAsync(
+			Path.Combine(this.StagingDirectory, "Project.csproj"),
+			"<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>netstandard2.0</TargetFramework></PropertyGroup><ItemGroup><PackageReference Include=\"Nerdbank.Streams\" /></ItemGroup></Project>",
+			TestContext.Current.CancellationToken);
 		this.packagesProps = this.MSBuild.GetProject(Path.Combine(this.StagingDirectory, DirectoryPackagesPropsFileName));
 	}
 
@@ -38,5 +42,76 @@ public class ReconcileVersionsCommandTests : CommandTestBase<ReconcileVersionsCo
 
 		AssertPackageVersion(this.packagesProps, "System.IO.Pipelines", "6.0.3");
 		Assert.False(Directory.Exists(Path.Combine(this.StagingDirectory, "nuget.frameworks")));
+	}
+
+	[Fact]
+	public async Task DiscoversTargetFrameworks()
+	{
+		string projectsDirectory = Path.Combine(this.StagingDirectory, "Projects");
+		Directory.CreateDirectory(projectsDirectory);
+		string singleTargetProject = string.Join(
+			Environment.NewLine,
+			[
+				"<Project Sdk=\"Microsoft.NET.Sdk\">",
+				"  <PropertyGroup>",
+				"    <TargetFramework>netstandard2.0</TargetFramework>",
+				"  </PropertyGroup>",
+				"</Project>",
+			]);
+		await File.WriteAllTextAsync(Path.Combine(projectsDirectory, "SingleTarget.csproj"), singleTargetProject, TestContext.Current.CancellationToken);
+
+		string multiTargetProject = string.Join(
+			Environment.NewLine,
+			[
+				"<Project Sdk=\"Microsoft.NET.Sdk\">",
+				"  <PropertyGroup>",
+				"    <TargetFrameworkList>net8.0;netstandard2.0</TargetFrameworkList>",
+				"    <TargetFrameworks>$(TargetFrameworkList)</TargetFrameworks>",
+				"  </PropertyGroup>",
+				"</Project>",
+			]);
+		await File.WriteAllTextAsync(Path.Combine(projectsDirectory, "MultiTarget.csproj"), multiTargetProject, TestContext.Current.CancellationToken);
+
+		// Introduce a downgrade issue that must be corrected for every discovered framework.
+		this.packagesProps.GetItemsByEvaluatedInclude("Nerdbank.Streams").Single().SetMetadataValue("Version", "2.9.112");
+		this.Command = new()
+		{
+			ProjectPath = projectsDirectory,
+		};
+
+		await this.ExecuteCommandAsync();
+
+		AssertPackageVersion(this.packagesProps, "System.IO.Pipelines", "6.0.3");
+	}
+
+	[Fact]
+	public async Task UsesExplicitTargetFrameworks()
+	{
+		// Introduce a downgrade issue.
+		this.packagesProps.GetItemsByEvaluatedInclude("Nerdbank.Streams").Single().SetMetadataValue("Version", "2.9.112");
+		this.Command = new()
+		{
+			ProjectPath = this.StagingDirectory,
+			TargetFrameworks = ["netstandard2.0", "net8.0", "net8.0"],
+		};
+
+		await this.ExecuteCommandAsync();
+
+		AssertPackageVersion(this.packagesProps, "System.IO.Pipelines", "6.0.3");
+	}
+
+	[Fact]
+	public async Task DoesNotReportSyntheticCompatibilityErrors()
+	{
+		this.packagesProps.AddItem("PackageVersion", "Cake.Core").Single().SetMetadataValue("Version", "6.2.0");
+		this.Command = new()
+		{
+			ProjectPath = this.StagingDirectory,
+			TargetFrameworks = ["net472"],
+		};
+
+		await this.ExecuteCommandAsync();
+
+		Assert.DoesNotContain("Cake.Core", ((StringWriter)this.Command.Error).ToString());
 	}
 }

--- a/test/Nerdbank.DotNetRepoTools.Tests/NuGet/UpgradeCommandTests.cs
+++ b/test/Nerdbank.DotNetRepoTools.Tests/NuGet/UpgradeCommandTests.cs
@@ -33,7 +33,7 @@ public class UpgradeCommandTests : CommandTestBase<UpgradeCommand>
 		{
 			PackageId = "Nerdbank.Streams",
 			PackageVersion = "2.9.112",
-			TargetFramework = "netstandard2.0",
+			TargetFrameworks = ["netstandard2.0", "net8.0", "net8.0"],
 			Path = this.StagingDirectory,
 		};
 


### PR DESCRIPTION
NuGet maintenance commands previously restored only `netstandard2.0`, forcing users to choose a single framework and missing multi-target dependency graphs.

`upgrade` and `reconcile-versions` now accept multiple `--framework` values or discover distinct evaluated target frameworks from projects under the requested path. Restore analysis runs across the resolved framework set while preserving the singular programmatic property for existing callers.

`reconcile-versions` suppresses compatibility diagnostics produced solely by its synthetic central-package graph, such as packages restored for frameworks that do not consume them. Unresolved package reporting and downgrade analysis are unchanged.

Fixes #3